### PR TITLE
release: automatización flujo 001 — creación de folio y datos generales

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,0 +1,3 @@
+{
+  "feature_directory": "specs/001-folio-creation-general-info"
+}

--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -1,0 +1,196 @@
+<!--
+=== Sync Impact Report ===
+Version change: 0.0.0 → 1.0.0
+Added principles:
+  - I. Screenplay Pattern
+  - II. Bounded Scope
+  - III. Declarative Gherkin
+  - IV. Test Data Independence
+  - V. Separation of Concerns
+  - VI. Language Convention
+  - VII. No Hardcoding
+  - VIII. GitFlow
+  - IX. No Self-Testing
+  - X. Pinned Dependencies
+  - XI. No Overengineering
+Added sections:
+  - Technology Stack
+  - Expected Deliverables
+Removed sections: none
+Templates requiring updates:
+  - .specify/templates/plan-template.md ✅ aligned (Constitution Check gate references these principles)
+  - .specify/templates/spec-template.md ✅ aligned (declarative Gherkin, Spanish language requirement)
+  - .specify/templates/tasks-template.md ✅ aligned (tests OPTIONAL note matches No Self-Testing principle)
+Follow-up TODOs: none
+===========================
+-->
+
+# AUTO_FRONT_SCREENPLAY Constitution
+
+## Core Principles
+
+### I. Screenplay Pattern
+
+Toda la automatización MUST seguir el patrón Screenplay de Serenity BDD:
+
+- Cada **Task** MUST implementar `Performable` y encapsular exactamente una
+  acción de negocio del usuario sobre la UI, o exactamente una operación HTTP
+  de setup de datos (ver principio IV).
+- Cada **Question** MUST implementar `Question<T>` y extraer exactamente un
+  dato observable de la UI.
+- El **Actor** interactúa con el sistema exclusivamente a través de Tasks y
+  Questions. Ningún otro componente toca WebDriver ni HTTP directamente.
+- Los localizadores de elementos MUST vivir en clases **Target** separadas
+  por página o sección (ej. `DashboardTargets`, `LocationsTargets`). NEVER
+  inline en Tasks ni en StepDefinitions.
+
+### II. Bounded Scope
+
+Este repositorio cubre exactamente **3 flujos críticos de UI**:
+
+- `001-folio-creation-and-general-info` — creación de folio y datos generales (full UI)
+- `002-locations-with-incomplete-alert` — registro de ubicaciones completa e incompleta con alerta (UI)
+- `003-premium-calculation-and-results` — coberturas, cálculo y desglose de prima (UI)
+
+No se MUST agregar flujos adicionales ni escenarios de error independientes
+fuera de estos tres. No se MUST usar Page Object Model ni Page Factory.
+
+### III. Declarative Gherkin
+
+Los archivos `.feature` MUST escribirse en Gherkin declarativo en español:
+
+- Máximo **5 steps por escenario**.
+- Un step = una acción de negocio completa. NEVER una interacción atómica
+  de UI (click, sendKeys, findElement, esperar N segundos).
+- Los steps NO MUST exponer CSS selectors, IDs de elementos, rutas de URL,
+  verbos HTTP, ni nombres literales de botones.
+- Correcto: `Cuando el agente registra una ubicación completa`
+- Incorrecto: `Cuando el agente hace clic en el botón "+ Añadir ubicación"`
+
+### IV. Test Data Independence
+
+Ningún escenario MUST depender de datos preexistentes en la base de datos:
+
+- **Capa 1 — Catálogos**: hook `@Before(order=1)` global verifica o crea
+  vía API los datos maestros mínimos (suscriptores, agentes, giros con clave
+  incendio, CP 06600, garantías tarifables) antes de arrancar cualquier
+  escenario.
+- **Capa 2 — Datos transaccionales**: cada escenario crea sus propios
+  folios y ubicaciones. Flow 001 los crea por UI (eso es lo que prueba).
+  Flows 002 y 003 los crean por API en `@Before(order=2)` para no repetir
+  cobertura ya validada en flujos anteriores.
+- El folio generado MUST propagarse entre steps con `actor.remember` /
+  `actor.recall`. NEVER con variables estáticas ni campos de instancia.
+
+### V. Separation of Concerns
+
+La responsabilidad de cada capa MUST estar estrictamente delimitada:
+
+- **StepDefinitions**: orquestación pura. NO MUST contener lógica de UI,
+  construcción de requests ni validaciones directas.
+- **Tasks UI** (`tasks/ui/`): acciones de usuario sobre la interfaz.
+- **Tasks API setup** (`tasks/api/`): operaciones HTTP con RestAssured para
+  establecer estado previo al test. Sin WebDriver.
+- **Questions** (`questions/`): extracción de un único dato observable de UI.
+- **Targets** (`targets/`): constantes `Target` agrupadas por página.
+- **Hooks** (`hooks/`): lógica `@Before` para setup de datos (Capas 1 y 2).
+- **Constants** (`utils/Constants.java`): todos los valores literales del
+  proyecto (ver principio VII).
+
+### VI. Language Convention
+
+- Todo el código (clases, métodos, variables, constantes, paquetes) MUST
+  estar en **inglés**.
+- Gherkin, specs, documentación y comentarios MUST estar en **español**.
+- Sin excepciones en ninguna dirección.
+
+### VII. No Hardcoding
+
+- Ningún valor literal (URLs, datos de prueba, códigos de catálogo, sumas
+  aseguradas, timeouts, porcentajes) MUST aparecer inline en Tasks, Questions,
+  StepDefinitions ni Hooks.
+- Todos los valores constantes MUST declararse en
+  `src/test/java/com/sofka/automation/utils/Constants.java`.
+- Ejemplos: `Constants.BASE_URL`, `Constants.TEST_ZIP_CODE`,
+  `Constants.FIRE_GUARANTEE_AMOUNT`, `Constants.BACKEND_BASE_URL`.
+
+### VIII. GitFlow
+
+- Rama de integración: **develop**. Toda feature parte de `develop`.
+- Nomenclatura: `feature/<nombre-descriptivo>`.
+- Merge a `develop` exclusivamente vía **Pull Request**. Sin push directo.
+- `main` recibe únicamente merges desde `release/*` o `hotfix/*`.
+- Commits en formato **Conventional Commits**:
+  `feat:`, `fix:`, `chore:`, `docs:`, `refactor:`, `test:`.
+
+### IX. No Self-Testing
+
+- Este repositorio NO MUST contener pruebas unitarias sobre el código de
+  automatización (Tasks, Questions, Targets, Hooks, Constants).
+- La validación del código ocurre ejecutando los escenarios Cucumber contra
+  el sistema real bajo prueba.
+- No se MUST crear clases de test para verificar Tasks ni Questions.
+
+### X. Pinned Dependencies
+
+Las versiones están fijadas y NO MUST modificarse salvo incompatibilidad
+demostrada y documentada:
+
+| Dependencia | Versión |
+|---|---|
+| Java | 21 |
+| Gradle plugin `net.serenity-bdd.serenity-gradle-plugin` | 4.2.34 |
+| serenity-core | 4.2.34 |
+| serenity-cucumber | 4.2.34 |
+| serenity-screenplay | 4.2.34 |
+| serenity-screenplay-webdriver | 4.2.34 |
+| selenium-java | 4.33.0 |
+| cucumber-junit-platform-engine | 7.22.2 |
+| junit-platform-suite | 1.12.2 |
+| junit-jupiter | 5.12.2 |
+| assertj-core | 3.27.3 |
+
+### XI. No Overengineering
+
+- La arquitectura MUST ser la mínima suficiente para los 3 flujos requeridos.
+- NO MUST crearse helpers, utilidades genéricas ni abstracciones para
+  operaciones de un solo uso.
+- NO MUST usarse `Thread.sleep`; usar esperas implícitas de Serenity WebDriver.
+
+## Technology Stack
+
+| Componente | Tecnología |
+|---|---|
+| Lenguaje | Java 21 |
+| Build tool | Gradle con `net.serenity-bdd.serenity-gradle-plugin` 4.2.34 |
+| Framework | Serenity BDD 4.2.34 |
+| Patrón | Screenplay (Tasks + Questions + Targets + Actor) |
+| WebDriver | serenity-screenplay-webdriver 4.2.34 + Selenium 4.33.0 |
+| HTTP setup | RestAssured (directo, en Tasks API y Hooks) |
+| Runner | Cucumber 7.22.2 + `cucumber-junit-platform-engine` 7.22.2 |
+| Engine | JUnit Platform Suite 1.12.2 + JUnit Jupiter 5.12.2 |
+| Aserciones | AssertJ 3.27.3 |
+| Browser | Chrome (`webdriver.driver=chrome` en `serenity.conf`) |
+| SUT | cotizador-danos-web Angular 19 en `http://localhost:4200` |
+| Backend | plataforma-danos-back en `http://localhost:8080` |
+
+## Expected Deliverables
+
+- Proyecto ejecutable con `gradle clean test aggregate`.
+- Reporte Serenity generado en `target/site/serenity/`.
+- `README.md` con instrucciones de ejecución y requisitos de ambiente.
+
+## Governance
+
+- Esta constitución es el documento rector del repositorio. Toda decisión de
+  diseño o implementación MUST ser consistente con los principios aquí definidos.
+- Enmiendas requieren: justificación documentada, actualización de versión
+  semántica y revisión de impacto en templates dependientes.
+- Política de versionado:
+  - MAJOR: eliminación o redefinición incompatible de principios existentes.
+  - MINOR: adición de principios o expansión material de guías.
+  - PATCH: correcciones de redacción, typos, refinamientos no semánticos.
+- Todo código entregado MUST verificarse contra estos principios antes de
+  considerarse completo.
+
+**Version**: 1.0.0 | **Ratified**: 2026-04-24 | **Last Amended**: 2026-04-24

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,48 @@
+# Insurance_Quoter_Auto_Front_Screenplay Development Guidelines
+
+Auto-generated from feature plans. Last updated: 2026-04-24
+
+## Active Technologies
+
+- Java 21 + Serenity BDD 4.2.34 + serenity-screenplay-webdriver 4.2.34 + Selenium 4.33.0 (001-folio-creation-general-info)
+
+## Project Structure
+
+```text
+src/test/java/com/sofka/automation/
+├── hooks/          — @Before hooks (catalog setup, transactional setup)
+├── tasks/ui/       — Performable Tasks para acciones UI
+├── tasks/api/      — Performable Tasks para setup HTTP (RestAssured)
+├── questions/      — Question<T> para estado observable de UI
+├── targets/        — Target locators por página
+├── stepdefinitions/
+├── runners/
+└── utils/Constants.java
+
+src/test/resources/
+├── features/
+└── serenity.conf
+```
+
+## Commands
+
+```bash
+./gradlew clean test aggregate
+```
+
+Reporte en `target/site/serenity/index.html`.
+
+## Code Style
+
+- Java 21: código en inglés, Gherkin en español
+- Sin hardcoding: todos los valores en Constants.java
+- Sin Thread.sleep: esperas implícitas de Serenity
+- Sin pruebas unitarias sobre Tasks/Questions (principio IX)
+- GitFlow: features desde develop, merge vía PR, Conventional Commits
+
+## Recent Changes
+
+- 001-folio-creation-general-info: setup inicial Java 21 + Serenity BDD Screenplay WebDriver
+
+<!-- MANUAL ADDITIONS START -->
+<!-- MANUAL ADDITIONS END -->

--- a/README.md
+++ b/README.md
@@ -1,0 +1,64 @@
+# Insurance Quoter Auto Front — Screenplay
+
+Automatización UI end-to-end del cotizador de daños usando **Java 21 + Serenity BDD 4.2.34 + Screenplay**.
+
+## Requisitos previos
+
+| Requisito | Verificación |
+|-----------|-------------|
+| Java 21 | `java -version` |
+| Google Chrome (última versión estable) | Automático via Selenium Manager |
+| Backend corriendo en `http://localhost:8080` | `curl http://localhost:8080/actuator/health` |
+| Core corriendo en `http://localhost:8081` | `curl http://localhost:8081/actuator/health` |
+| SPA Angular corriendo en `http://localhost:4200` | Abrir en browser |
+
+## Ejecución
+
+```bash
+./gradlew clean test aggregate
+```
+
+El hook `@Before(order=1)` verifica y crea catálogos automáticamente. No se requieren seeds manuales.
+
+## Filtrar por feature
+
+```bash
+./gradlew clean test aggregate -Dcucumber.filter.tags="@folio-creation"
+```
+
+## Reporte
+
+```
+target/site/serenity/index.html
+```
+
+Abrir en Windows:
+```bash
+start target/site/serenity/index.html
+```
+
+## Estructura
+
+```
+src/test/java/com/sofka/automation/
+├── hooks/          — @Before hooks (setup de catálogos vía API)
+├── tasks/ui/       — Performable Tasks para acciones UI
+├── tasks/api/      — Performable Tasks para setup HTTP
+├── questions/      — Question<T> para estado observable de UI
+├── targets/        — Target locators por página
+├── stepdefinitions/
+├── runners/
+└── utils/Constants.java
+
+src/test/resources/
+├── features/
+└── serenity.conf
+```
+
+## Principios de diseño
+
+- **Screenplay Pattern**: Tasks, Questions, Targets, Actor — sin Page Object Model
+- **Sin hardcoding**: todos los valores literales en `Constants.java`
+- **Sin Thread.sleep**: esperas implícitas de Serenity
+- **Gherkin declarativo**: máximo 5 steps en español, lenguaje de negocio
+- **Independencia de datos**: hook `@Before` garantiza catálogos; cada escenario crea sus datos transaccionales por UI

--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,35 @@
+plugins {
+    id 'java'
+    id 'net.serenity-bdd.serenity-gradle-plugin' version '4.2.34'
+}
+
+group = 'com.sofka'
+version = '1.0.0'
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    testImplementation 'net.serenity-bdd:serenity-core:4.2.34'
+    testImplementation 'net.serenity-bdd:serenity-cucumber:4.2.34'
+    testImplementation 'net.serenity-bdd:serenity-screenplay:4.2.34'
+    testImplementation 'net.serenity-bdd:serenity-screenplay-webdriver:4.2.34'
+    testImplementation 'org.seleniumhq.selenium:selenium-java:4.33.0'
+    testImplementation 'io.cucumber:cucumber-junit-platform-engine:7.22.2'
+    testImplementation 'org.junit.platform:junit-platform-suite:1.12.2'
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.12.2'
+    testImplementation 'org.assertj:assertj-core:3.27.3'
+    testImplementation 'io.rest-assured:rest-assured:5.3.2'
+}
+
+test {
+    useJUnitPlatform()
+    finalizedBy aggregate
+}

--- a/docs/speckit-inputs-auto-front-screenplay.md
+++ b/docs/speckit-inputs-auto-front-screenplay.md
@@ -98,3 +98,14 @@ atómico). Tasks API: RestAssured directo para setup de precondiciones.
 Targets por página. Sin Thread.sleep; esperas implícitas de Serenity.
 Un runner por feature. Plugin Serenity: SerenityReporterParallel.
 ```
+
+---
+
+## `speckit implement`
+
+```
+El código fuente del frontend a automatizar está en:
+D:\Trabajo\Sofka\Insurance-Quoter\Insurance-Quoter\Insurance-Quoter-Front\
+Leer los componentes Angular para extraer los selectores CSS correctos
+antes de escribir las clases Target.
+```

--- a/docs/speckit-inputs-auto-front-screenplay.md
+++ b/docs/speckit-inputs-auto-front-screenplay.md
@@ -1,492 +1,100 @@
 # Inputs para SpecKit — Auto_Front_Screenplay
 
-Referencia de los textos a pegar en cada comando de SpecKit al inicializar
-el proyecto `Auto_Front_Screenplay` de automatización de UI.
+Textos cortos a pegar en cada comando de SpecKit. El AI genera los documentos
+completos a partir de estos inputs.
 
-Orden de ejecución:
+---
+
+## `speckit constitution`
+
 ```
-speckit constitution
-speckit specify   # correr 3 veces (una por feature)
-speckit plan      # correr 3 veces (una por spec generada)
+Proyecto de automatización UI end-to-end para la SPA cotizador-danos-web
+(Angular 19, http://localhost:4200) usando Java 21 + Serenity BDD 4.2.34 +
+serenity-screenplay-webdriver 4.2.34 + Selenium 4.33.0 + Cucumber 7.22.2.
+Patrón Screenplay obligatorio (Tasks, Questions, Targets, Actor); sin Page
+Object Model. Gherkin declarativo en español, máximo 5 steps por escenario.
+Código siempre en inglés; specs y documentación en español. Sin hardcoding:
+todos los valores literales en Constants.java. Sin pruebas unitarias sobre
+el código de automatización. GitFlow: rama base develop, features por PR,
+Conventional Commits. Test data independence: hook @Before verifica o crea
+catálogos vía API; cada escenario crea sus propios datos transaccionales.
+Dependencias fijadas; no modificar versiones.
 ```
 
 ---
 
-## Estrategia de datos de prueba
-
-Antes de leer los inputs, entender la estrategia de dos capas que aplica
-a todos los escenarios:
+## `speckit specify` — Feature 001
 
 ```
-Capa 1 — Datos maestros / catálogos (hook @Before global)
-  Responsabilidad: verificar que los catálogos requeridos existen en la BD.
-  Si no existen → crearlos vía API antes de que arranque cualquier escenario.
-  Datos mínimos: al menos 1 suscriptor, 1 agente, 1 giro con clave incendio,
-  CP 06600 con colonias asociadas, al menos 1 garantía tarifable.
-  Implementación: clase CatalogSetupHook con @Before(order=1).
-
-Capa 2 — Datos transaccionales (por escenario)
-  Cada escenario crea sus propios folios y ubicaciones; no asume ningún
-  folio preexistente en la BD.
-
-  Flow 001: folio + datos generales creados por UI (ESO es lo que prueba).
-  Flow 002: folio + datos generales + layout creados por API (@Before),
-            luego UI para registrar y verificar ubicaciones.
-  Flow 003: folio + datos generales + layout + ubicaciones creados por API
-            (@Before), luego UI para coberturas + cálculo + resultados.
+speckit specify 001-folio-creation-and-general-info
 ```
 
-Esta separación garantiza que cada escenario prueba el comportamiento
-de UI que le corresponde y no falla por estado sucio de BD.
-
----
-
-## 1. `speckit constitution`
-
-```
-Proyecto: AUTO_FRONT_SCREENPLAY
-
-Repositorio de automatización end-to-end de la SPA cotizador-danos-web
-(Angular 19, http://localhost:4200) del sistema Insurance Quoter.
-Tecnología: Java 21 + Serenity BDD 4.2.34 + serenity-screenplay-webdriver
-4.2.34 + Selenium 4.33.0 + Cucumber 7.22.2.
-
-El proyecto es hermano de AUTO_API_SCREENPLAY (que cubre endpoints REST)
-y sigue la misma disciplina de patrón Screenplay adaptada a UI.
-
-Principios obligatorios:
-
-I. Screenplay Pattern
-- Cada Task implementa Performable y encapsula exactamente una acción
-  de negocio de usuario sobre la UI, o exactamente una operación HTTP de
-  setup (ver principio V). No ejecuta validaciones.
-- Cada Question implementa Question<T> y extrae exactamente un dato
-  observable de la UI.
-- El Actor interactúa con el sistema exclusivamente a través de Tasks y
-  Questions; ningún otro componente toca WebDriver ni HTTP directamente.
-- Los localizadores de elementos DEBEN vivir en clases Target separadas
-  por página o sección; nunca inline en Tasks ni en StepDefinitions.
-
-II. Bounded Scope
-- El repositorio cubre exactamente 3 flujos críticos:
-    001 — Creación de folio y captura de datos generales (full UI)
-    002 — Registro de ubicaciones: completa e incompleta con alerta (UI)
-    003 — Configuración de coberturas, cálculo y desglose de prima (UI)
-- Sin flujos adicionales ni escenarios de error independientes.
-- Sin Page Object Model ni Page Factory.
-
-III. Declarative Gherkin (máximo 5 steps por escenario)
-- Gherkin en español, código en inglés.
-- Un step = una acción de negocio completa. Prohibido exponer clicks,
-  selects, CSS selectors, IDs, rutas de URL, verbos HTTP.
-- Cada escenario cubre exactamente un comportamiento observable del sistema.
-
-IV. Test Data Independence
-- Ningún escenario depende de datos preexistentes en la base de datos.
-- Dos capas de setup:
-    Capa 1: hook @Before(order=1) global verifica o crea datos maestros
-             (catálogos) vía API antes de arrancar cualquier escenario.
-    Capa 2: cada escenario crea sus propios datos transaccionales
-             (folios, ubicaciones) ya sea por UI o por API según su alcance.
-- Los datos transaccionales creados por API en la Capa 2 usan Tasks de
-  setup que llaman a RestAssured directamente (sin Screenplay WebDriver).
-- El folio generado se propaga entre steps usando actor.remember /
-  actor.recall; nunca variables estáticas ni campos de instancia.
-
-V. Separation of Concerns
-- StepDefinitions: orquestación pura. Sin lógica de UI ni HTTP.
-- Tasks UI (tasks/ui/): acciones de usuario sobre la interfaz.
-- Tasks API setup (tasks/api/): operaciones HTTP para establecer estado
-  previo al test de UI. Usan RestAssured directamente.
-- Hooks (hooks/): @Before para setup de catálogos y datos transaccionales.
-- Questions (questions/): extracción de un dato observable de la UI.
-- Targets (targets/): constantes Target agrupadas por página.
-
-VI. Language Convention
-- Todo el código (clases, métodos, variables, constantes) DEBE estar en inglés.
-- Gherkin, specs, documentación y comentarios DEBEN estar en español.
-- Sin excepciones.
-
-VII. No Hardcoding
-- Ningún valor literal (URLs, credenciales, datos de prueba, timeouts,
-  códigos de catálogo) puede estar inline en Tasks, Questions ni StepDefinitions.
-- Todos los valores constantes DEBEN declararse en la clase utilitaria
-  `Constants` (src/test/java/com/sofka/automation/utils/Constants.java).
-- Ejemplo: Constants.BASE_URL, Constants.TEST_ZIP_CODE, Constants.FIRE_GUARANTEE_AMOUNT.
-
-VIII. GitFlow
-- Rama principal de integración: develop.
-- Toda nueva feature parte de develop con rama feature/<nombre-descriptivo>.
-- Merge a develop solo vía Pull Request.
-- main recibe únicamente merges desde release/* o hotfix/*.
-- Prohibido push directo a main o develop.
-- Commits en Conventional Commits: feat:, fix:, chore:, docs:, refactor:.
-
-IX. No Self-Testing
-- Este repositorio NO contiene pruebas unitarias sobre el código de
-  automatización (Tasks, Questions, Targets, Hooks).
-- La validación del código de automatización ocurre ejecutando los
-  escenarios Cucumber contra el sistema real.
-- No se crean clases de test para verificar Tasks ni Questions.
-
-X. Pinned Dependencies
-
-| Componente                           | Versión |
-|--------------------------------------|---------|
-| Java                                 | 21      |
-| Gradle plugin serenity-gradle-plugin | 4.2.34  |
-| serenity-core                        | 4.2.34  |
-| serenity-cucumber                    | 4.2.34  |
-| serenity-screenplay                  | 4.2.34  |
-| serenity-screenplay-webdriver        | 4.2.34  |
-| selenium-java                        | 4.33.0  |
-| cucumber-junit-platform-engine       | 7.22.2  |
-| junit-platform-suite                 | 1.12.2  |
-| junit-jupiter                        | 5.12.2  |
-| assertj-core                         | 3.27.3  |
-
-XI. No Overengineering
-- Arquitectura mínima para los 3 flujos requeridos.
-- Sin helpers ni utilidades genéricas para operaciones de un solo uso.
-- Sin escenarios de error adicionales fuera del alcance de cada spec.
-
-Stack:
-- Lenguaje: Java 21 | Build: Gradle con serenity-gradle-plugin 4.2.34
-- Framework: Serenity BDD 4.2.34
-- Patrón: Screenplay (Tasks + Questions + Targets + Actor)
-- WebDriver: serenity-screenplay-webdriver 4.2.34 + Selenium 4.33.0
-- HTTP setup: RestAssured (directo, en Tasks API y Hooks)
-- Runner: Cucumber 7.22.2 + cucumber-junit-platform-engine 7.22.2
-- Engine: JUnit Platform Suite 1.12.2 + JUnit Jupiter 5.12.2
-- Aserciones: AssertJ 3.27.3
-- Browser: Chrome (webdriver.driver=chrome en serenity.conf)
-
-Entregables:
-- Proyecto ejecutable: gradle clean test aggregate
-- Reporte Serenity: target/site/serenity/
-- README.md con pasos de ejecución y requisitos de ambiente
-```
-
----
-
-## Contexto de UI real
-
-Observaciones del frontend real que los inputs de `speckit specify`
-describen y que las Tasks deben implementar.
-
-### Flujo wizard de 5 pasos
-`Datos generales → Layout → Ubicaciones → Coberturas → Cálculo`
-
-### Paso 0 — Dashboard y creación de folio
-- Página `/cotizador`, "Panel de folios"
-- Botón "+ Nuevo folio" abre modal con dos dropdowns: Suscriptor + Agente
-- Botón "Crear folio" genera número de folio (`FOL-YYYY-NNNNN`) y redirige al wizard
-
-### Paso 1 — Datos generales
-- Sección "Asegurado": Razón social, RFC, Correo de contacto, Teléfono
-- Sección "Suscripción": Suscriptor (precargado del modal), Agente (precargado),
-  Clasificación de riesgo (dropdown), Tipo de negocio (dropdown)
-- Badge "• Completo" por sección cuando todos los campos requeridos están llenos
-- Botones: "← Anterior" | "Guardar borrador" | "Siguiente →"
-
-### Paso 2 — Layout
-- Número de ubicaciones (numérico) + Tipo: "Ubicación única" / "Múltiples ubicaciones"
-- Botones: "← Anterior" | "Guardar borrador" | "Siguiente →"
-
-### Paso 3 — Ubicaciones
-- Tabla: #, Nombre, Dirección·CP, Giro, Construcción, Suma asegurada, Estado
-- Botón "+ Añadir ubicación" abre drawer lateral con 4 tabs:
-  - Datos básicos: Nombre, Dirección, CP (autocompleta Estado/Municipio/Ciudad/Colonia)
-  - Construcción: Tipo constructivo (radio), Niveles, Año
-  - Giro: dropdown de catálogo (asociado a clave incendio)
-  - Garantías: checkboxes con monto (GUA-FIRE, GUA-CONT, GUA-THEFT, GUA-GLASS,
-    GUA-ELEC, GUA-CASH)
-- Footer del drawer: tags de alertas activas ("CP faltante", "Clave incendio
-  faltante", "Sin garantías activas") + botón "Guardar ubicación"
-- Badge en tabla: "Completa" (verde) o "Incompleta (N)" (rojo)
-- Banner amarillo cuando hay alertas bloqueantes activas
-
-### Paso 4 — Coberturas
-- Tabs por ubicación (UBIC 01, UBIC 02...)
-- Coberturas con toggle + Deducible (%) + Coaseguro (%):
-  COV-FIRE (Incendio), COV-CAT (Catastrófica), COV-BI (Interrupción de negocio)
-- Botones: "← Anterior" | "Guardar coberturas" | "Siguiente →"
-
-### Paso 5 — Cálculo
-- Antes de ejecutar: conteo "N calculables / N con alertas" + botón "Ejecutar cálculo"
-- Después de ejecutar (sin recarga de página):
-  - Card "PRIMA NETA" con valor numérico
-  - Card "PRIMA COMERCIAL" con valor numérico
-  - Card "POR UBICACIÓN": prima numérica o badge "No calculable" por ubicación
-  - Sección "Ubicaciones no calculadas" con razones ("CP requerido",
-    "Clave incendio requerida", "Se requiere garantía tarifable")
-  - Botón "Continuar a términos y condiciones"
-
----
-
-## 2. `speckit specify` — Feature 001
-
-Nombre: `001-folio-creation-and-general-info`
+Input:
 
 ```
 Automatización del flujo de creación de folio y captura de datos generales
-en la SPA cotizador-danos-web. Este escenario prueba la UI de principio a
-fin: desde el dashboard hasta completar el primer paso del wizard.
-
-Estrategia de datos:
-- Capa 1 (hook @Before global): verificar o crear vía API al menos 1
-  suscriptor y 1 agente en los catálogos. Si existen, no se recrean.
-- Capa 2 (este escenario): el folio se crea por UI — eso es exactamente
-  lo que se está probando.
-
-Escenario Gherkin (declarativo, máximo 5 steps):
-
-  Scenario: El agente crea un folio y registra los datos generales del asegurado
-    Given el agente está en el panel de cotizaciones
-    When crea un nuevo folio con un suscriptor y agente disponibles
-    And completa los datos del asegurado y la suscripción
-    Then ambas secciones muestran estado completo
-    And el folio aparece en la barra de progreso del wizard
-
-Flujo de UI que respalda cada step:
-
-  When "crea un nuevo folio...":
-    Task CreateFolio:
-      - Hace clic en "+ Nuevo folio"
-      - Selecciona primer elemento disponible en dropdown Suscriptor
-      - Selecciona primer elemento disponible en dropdown Agente
-      - Hace clic en "Crear folio"
-      - Extrae número de folio de la URL o del DOM y llama actor.remember("folioNumber")
-
-  And "completa los datos del asegurado...":
-    Task CompleteGeneralInfo:
-      - Llena Razón social, RFC, Correo, Teléfono con valores fijos de prueba
-      - Selecciona primera opción en Clasificación de riesgo
-      - Selecciona primera opción en Tipo de negocio
-      - Hace clic en "Siguiente →"
-
-  Then "ambas secciones muestran estado completo":
-    Question SectionStatus: verifica presencia de badge "• Completo" en ambas secciones
-
-  And "el folio aparece en la barra de progreso":
-    Question WizardStep: verifica que el stepper indica paso 2 (Layout) activo
-
-Supuestos:
-- Backend http://localhost:8080 y core http://localhost:8081 corriendo.
-- Los catálogos tienen al menos un suscriptor y un agente (garantizado por Capa 1).
-- Sin autenticación requerida.
-- Valores de prueba hardcodeados en CompleteGeneralInfo (RFC ECO860313AB2,
-  razón social "Empresa Prueba SA de CV", etc.). Sin Scenario Outline.
+en la SPA cotizador-danos-web. El agente abre el modal "+ Nuevo folio" desde
+el dashboard, selecciona suscriptor y agente, crea el folio y completa los
+datos del asegurado (razón social, RFC, correo, teléfono) y suscripción
+(clasificación de riesgo, tipo de negocio). El escenario verifica que ambas
+secciones muestran estado completo y el wizard avanza al paso de layout.
+Setup: hook @Before garantiza catálogos mínimos vía API. Folio creado por UI
+(eso es lo que prueba). Folio propagado con actor.remember("folioNumber").
 ```
 
 ---
 
-## 3. `speckit specify` — Feature 002
-
-Nombre: `002-locations-with-incomplete-alert`
+## `speckit specify` — Feature 002
 
 ```
-Automatización del comportamiento de la UI al registrar una ubicación
-incompleta en la sección Ubicaciones de riesgo. El escenario prueba que
-el sistema muestra alertas bloqueantes en la UI sin impedir continuar.
+speckit specify 002-locations-with-incomplete-alert
+```
 
-Estrategia de datos:
-- Capa 1 (hook @Before global): verificar o crear vía API al menos 1 giro
-  con clave incendio válida, CP 06600 con colonias, y garantías tarifables.
-- Capa 2 (hook @Before de este feature): crear vía API el estado previo
-  necesario para que el test empiece directamente en la sección de Ubicaciones:
-    POST /v1/folios                           → obtener folioNumber
-    PUT  /v1/quotes/{folio}/general-info      → datos mínimos válidos
-    PUT  /v1/quotes/{folio}/locations/layout  → { numberOfLocations: 2 }
-  El folio creado se guarda con actor.remember("folioNumber").
-  El browser se abre directamente en /quotes/{folio}/locations.
-- Por qué API para el setup: crear folio + general info + layout por UI es
-  comportamiento ya cubierto en flow 001. Repetirlo aquí agrega tiempo de
-  ejecución sin agregar cobertura nueva.
+Input:
 
-Escenario Gherkin (declarativo, máximo 5 steps):
-
-  Scenario: El sistema alerta sobre ubicación incompleta sin bloquear el folio
-    Given existe un folio con layout configurado para 2 ubicaciones
-    When el agente registra una ubicación completa y una sin datos requeridos
-    Then la primera ubicación aparece en estado válido
-    And la segunda muestra alertas bloqueantes en la tabla
-
-Flujo de UI que respalda cada step:
-
-  Given "existe un folio con layout...":
-    Task SetUpFolioWithLayout (API, no WebDriver):
-      - POST /v1/folios → guarda folioNumber
-      - PUT /v1/quotes/{folio}/general-info
-      - PUT /v1/quotes/{folio}/locations/layout { numberOfLocations: 2 }
-      - Navega browser a /quotes/{folioNumber}/locations
-
-  When "registra una ubicación completa...":
-    Task RegisterCompleteLocation (WebDriver):
-      - Clic en "+ Añadir ubicación"
-      - Tab Datos básicos: nombre "Ubicación 1", CP "06600", espera autocompletado
-      - Tab Construcción: selecciona Mampostería, niveles 1, año 2000
-      - Tab Giro: selecciona primer giro disponible con clave incendio
-      - Tab Garantías: activa GUA-FIRE con suma 1000000
-      - Clic "Guardar ubicación"
-    Task RegisterIncompleteLocation (WebDriver):
-      - Clic en "+ Añadir ubicación"
-      - Tab Datos básicos: nombre "Ubicación 2" únicamente (sin CP, sin dirección)
-      - No toca tabs Giro ni Garantías
-      - Clic "Guardar ubicación"
-
-  Then / And:
-    Question LocationRowStatus(1): extrae badge de estado de fila 1 → "Completa"
-    Question LocationRowStatus(2): extrae badge de estado de fila 2 → "Incompleta (3)"
-    Question BlockingAlertBannerVisible: verifica presencia del banner amarillo
-
-Supuestos:
-- CP 06600 existe en catálogo (garantizado por Capa 1).
-- Guardar ubicación sin CP/giro/garantías acepta el guardado pero retorna
-  estado incompleto (la UI no bloquea el guardado).
-- Los tags "CP faltante", "Clave incendio faltante", "Sin garantías activas"
-  son visibles en el drawer antes de guardar.
+```
+Automatización del registro de ubicaciones en la SPA cotizador-danos-web:
+una ubicación completa (CP válido, giro con clave incendio, garantía tarifable)
+y una incompleta (solo nombre, sin CP ni giro ni garantías). El escenario
+verifica que la UI muestra badge "Incompleta" y banner de alertas bloqueantes
+para la segunda ubicación sin bloquear el folio. Setup vía API antes de abrir
+el browser: POST /v1/folios, PUT general-info, PUT layout (2 ubicaciones).
+La UI se prueba desde la pantalla de Ubicaciones; la creación de folio y datos
+generales ya están cubiertos en el flujo 001.
 ```
 
 ---
 
-## 4. `speckit specify` — Feature 003
-
-Nombre: `003-premium-calculation-and-results`
+## `speckit specify` — Feature 003
 
 ```
-Automatización del flujo de configuración de coberturas, ejecución del
-cálculo de prima y verificación del desglose de resultados. Cubre los
-pasos 4 (Coberturas) y 5 (Cálculo) del wizard.
+speckit specify 003-premium-calculation-and-results
+```
 
-Estrategia de datos:
-- Capa 1 (hook @Before global): verificar catálogos (mismos de features 001/002).
-- Capa 2 (hook @Before de este feature): crear vía API todo el estado previo
-  necesario para que el test empiece directamente en Coberturas:
-    POST /v1/folios
-    PUT  /v1/quotes/{folio}/general-info
-    PUT  /v1/quotes/{folio}/locations/layout     → { numberOfLocations: 2 }
-    PUT  /v1/quotes/{folio}/locations            → ubicación 1 completa
-    PATCH /v1/quotes/{folio}/locations/2         → ubicación 2: solo nombre
-  El folio creado se guarda con actor.remember("folioNumber").
-  El browser se abre directamente en el paso 4 (Coberturas).
-- Por qué API para el setup: el comportamiento de ubicaciones ya está cubierto
-  en flow 002. Repetirlo aquí no agrega cobertura; sí agrega fragilidad y tiempo.
+Input:
 
-Escenario Gherkin (declarativo, máximo 5 steps):
-
-  Scenario: El sistema calcula la prima de la ubicación válida y omite la incompleta
-    Given existe un folio con una ubicación completa y una incompleta registradas
-    When el agente activa la cobertura de incendio y ejecuta el cálculo de prima
-    Then el desglose muestra prima neta y prima comercial con valores positivos
-    And la ubicación completa tiene prima calculada y la incompleta aparece como no calculable
-
-Flujo de UI que respalda cada step:
-
-  Given "existe un folio con una ubicación completa y una incompleta":
-    Task SetUpFolioWithLocations (API, no WebDriver):
-      - POST /v1/folios → guarda folioNumber
-      - PUT /v1/quotes/{folio}/general-info
-      - PUT /v1/quotes/{folio}/locations/layout { numberOfLocations: 2 }
-      - PUT /v1/quotes/{folio}/locations (ubicación 1 completa: CP 06600,
-        giro con claveIncendio, garantía GUA-FIRE con suma 1000000)
-      - PATCH /v1/quotes/{folio}/locations/2 (solo nombre "Ubicación 2")
-      - Navega browser a paso 4 (Coberturas)
-
-  When "activa la cobertura de incendio y ejecuta el cálculo":
-    Task ActivateFireCoverageAndCalculate (WebDriver):
-      - En tab UBIC 01: activa toggle COV-FIRE, deja Deducible y Coaseguro
-        con valores por defecto
-      - Clic "Guardar coberturas"
-      - Clic "Siguiente →" para ir al paso 5 (Cálculo)
-      - Clic "Ejecutar cálculo"
-      - Espera hasta que card "PRIMA NETA" sea visible (espera implícita
-        de Serenity WebDriver; sin Thread.sleep)
-
-  Then "el desglose muestra prima neta y prima comercial":
-    Question NetPremiumValue: extrae texto del card PRIMA NETA → valor > 0
-    Question CommercialPremiumValue: extrae texto del card PRIMA COMERCIAL → valor > 0
-
-  And "la ubicación completa tiene prima / la incompleta es no calculable":
-    Question LocationPremiumStatus(1): extrae valor numérico de Ubicación 1
-    Question LocationPremiumStatus(2): verifica badge "No calculable" en Ubicación 2
-    Question UncalculatedAlertVisible: verifica sección "Ubicaciones no calculadas"
-
-Supuestos:
-- El backend calcula prima > 0 para la combinación: CP 06600 + giro con
-  claveIncendio + GUA-FIRE activa.
-- La UI actualiza el desglose sin redirigir (Angular actualiza el componente).
-- No se valida el valor exacto de la prima; solo que sea numérico y positivo.
-- El paso de términos y condiciones NO se automatiza en este escenario.
+```
+Automatización del flujo de coberturas + cálculo de prima en la SPA
+cotizador-danos-web. El agente activa la cobertura COV-FIRE en la ubicación
+completa, guarda, y ejecuta el cálculo. El escenario verifica que el desglose
+muestra prima neta y prima comercial con valores positivos, que la ubicación
+completa tiene prima calculada y que la incompleta aparece como "No calculable"
+con sus alertas. Setup vía API: POST folio, PUT general-info, PUT layout,
+PUT/PATCH ubicaciones (1 completa, 1 incompleta). UI se prueba desde coberturas;
+flows 001 y 002 ya cubren los pasos previos.
 ```
 
 ---
 
-## 5. `speckit plan` — Contexto adicional
+## `speckit plan`
 
-Si `speckit plan` pide contexto adicional, pegar el siguiente bloque
-(aplica a los 3 planes sin modificación):
+El comando lee la spec generada automáticamente. Si pide contexto adicional:
 
 ```
-Stack: Java 21 + Serenity BDD 4.2.34 + serenity-screenplay-webdriver 4.2.34
-+ Selenium 4.33.0 + Cucumber 7.22.2 + JUnit Platform Suite 1.12.2.
-Browser: Chrome. Build: Gradle single-module.
-
-Estructura de paquetes bajo src/test/java/com/sofka/automation/:
-  tasks/ui/       — Tasks WebDriver (Performable), una por acción de negocio
-  tasks/api/      — Tasks de setup HTTP (RestAssured), sin Screenplay
-  questions/      — Questions<T> para estado observable de UI
-  targets/        — constantes Target por página:
-                    DashboardTargets, GeneralInfoTargets, LocationsTargets,
-                    CoveragesTargets, CalculationTargets
-  stepdefinitions/
-  runners/
-  hooks/          — CatalogSetupHook (@Before order=1, verifica/crea catálogos)
-  utils/          — Constants.java (todos los valores literales del proyecto:
-                    URLs, datos de prueba, códigos de catálogo, timeouts)
-
-Decisiones bloqueadas (no reabrir):
-- Screenplay; sin Page Object Model.
-- Targets en clases separadas por página; nunca inline.
-- Tasks UI: una Task por acción de negocio completa (no por click atómico).
-- Tasks API en tasks/api/: RestAssured directo. No usan WebDriver.
-- CatalogSetupHook: @Before(order=1), compartido por los 3 features.
-  Verifica via GET que catálogos existen; si no, los crea via POST.
-- Setup transaccional por feature: @Before(order=2) específico por feature,
-  implementado como Task API que crea el folio y su estado previo.
-- Estado via actor.remember("folioNumber") / actor.recall("folioNumber").
-- serenity.conf: webdriver.driver=chrome,
-  serenity.base.url=http://localhost:4200,
-  restapi.base.url=http://localhost:8080.
-- Un runner por feature: FolioTestRunner, LocationsTestRunner,
-  CalculationTestRunner.
-- Plugin Serenity: io.cucumber.core.plugin.SerenityReporterParallel.
-- Specs bajo specs/: 001-folio-creation-and-general-info/,
-  002-locations-with-incomplete-alert/, 003-premium-calculation-and-results/.
-
-Restricciones:
-- Versiones de dependencias fijadas por constitución; no cambiar.
-- Sin Thread.sleep; usar esperas implícitas de Serenity WebDriver.
-- Sin helpers genéricos para operaciones de un solo uso.
-- Sin valores literales inline; todos en Constants.java.
-- Sin pruebas unitarias sobre el código de automatización.
-- GitFlow: features parten de develop, merge solo vía PR.
-- Commits en Conventional Commits.
-```
-
----
-
-## Referencia rápida de comandos
-
-```bash
-speckit init          # omitir si ya existe .specify/
-speckit constitution  # → pegar sección 1
-
-speckit specify 001-folio-creation-and-general-info   # → sección 2
-speckit specify 002-locations-with-incomplete-alert   # → sección 3
-speckit specify 003-premium-calculation-and-results   # → sección 4
-
-speckit plan 001-folio-creation-and-general-info      # → sección 5 si la pide
-speckit plan 002-locations-with-incomplete-alert      # → sección 5 si la pide
-speckit plan 003-premium-calculation-and-results      # → sección 5 si la pide
+Stack: Java 21, Serenity BDD 4.2.34, Selenium 4.33.0, Cucumber 7.22.2,
+Chrome. Paquetes: tasks/ui/, tasks/api/, questions/, targets/, hooks/,
+utils/Constants.java. Tasks UI: una por acción de negocio (no por click
+atómico). Tasks API: RestAssured directo para setup de precondiciones.
+Targets por página. Sin Thread.sleep; esperas implícitas de Serenity.
+Un runner por feature. Plugin Serenity: SerenityReporterParallel.
 ```

--- a/docs/speckit-inputs-auto-front-screenplay.md
+++ b/docs/speckit-inputs-auto-front-screenplay.md
@@ -102,11 +102,34 @@ V. Separation of Concerns
 - Questions (questions/): extracción de un dato observable de la UI.
 - Targets (targets/): constantes Target agrupadas por página.
 
-VI. Code Clarity
-- Código en inglés. Gherkin y documentación en español.
-- Nombres semánticos y autoexplicativos. Sin código comentado.
+VI. Language Convention
+- Todo el código (clases, métodos, variables, constantes) DEBE estar en inglés.
+- Gherkin, specs, documentación y comentarios DEBEN estar en español.
+- Sin excepciones.
 
-VII. Pinned Dependencies
+VII. No Hardcoding
+- Ningún valor literal (URLs, credenciales, datos de prueba, timeouts,
+  códigos de catálogo) puede estar inline en Tasks, Questions ni StepDefinitions.
+- Todos los valores constantes DEBEN declararse en la clase utilitaria
+  `Constants` (src/test/java/com/sofka/automation/utils/Constants.java).
+- Ejemplo: Constants.BASE_URL, Constants.TEST_ZIP_CODE, Constants.FIRE_GUARANTEE_AMOUNT.
+
+VIII. GitFlow
+- Rama principal de integración: develop.
+- Toda nueva feature parte de develop con rama feature/<nombre-descriptivo>.
+- Merge a develop solo vía Pull Request.
+- main recibe únicamente merges desde release/* o hotfix/*.
+- Prohibido push directo a main o develop.
+- Commits en Conventional Commits: feat:, fix:, chore:, docs:, refactor:.
+
+IX. No Self-Testing
+- Este repositorio NO contiene pruebas unitarias sobre el código de
+  automatización (Tasks, Questions, Targets, Hooks).
+- La validación del código de automatización ocurre ejecutando los
+  escenarios Cucumber contra el sistema real.
+- No se crean clases de test para verificar Tasks ni Questions.
+
+X. Pinned Dependencies
 
 | Componente                           | Versión |
 |--------------------------------------|---------|
@@ -122,7 +145,7 @@ VII. Pinned Dependencies
 | junit-jupiter                        | 5.12.2  |
 | assertj-core                         | 3.27.3  |
 
-VIII. No Overengineering
+XI. No Overengineering
 - Arquitectura mínima para los 3 flujos requeridos.
 - Sin helpers ni utilidades genéricas para operaciones de un solo uso.
 - Sin escenarios de error adicionales fuera del alcance de cada spec.
@@ -419,6 +442,8 @@ Estructura de paquetes bajo src/test/java/com/sofka/automation/:
   stepdefinitions/
   runners/
   hooks/          — CatalogSetupHook (@Before order=1, verifica/crea catálogos)
+  utils/          — Constants.java (todos los valores literales del proyecto:
+                    URLs, datos de prueba, códigos de catálogo, timeouts)
 
 Decisiones bloqueadas (no reabrir):
 - Screenplay; sin Page Object Model.
@@ -443,6 +468,10 @@ Restricciones:
 - Versiones de dependencias fijadas por constitución; no cambiar.
 - Sin Thread.sleep; usar esperas implícitas de Serenity WebDriver.
 - Sin helpers genéricos para operaciones de un solo uso.
+- Sin valores literales inline; todos en Constants.java.
+- Sin pruebas unitarias sobre el código de automatización.
+- GitFlow: features parten de develop, merge solo vía PR.
+- Commits en Conventional Commits.
 ```
 
 ---

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'Insurance_Quoter_Auto_Front_Screenplay'

--- a/specs/001-folio-creation-general-info/checklists/requirements.md
+++ b/specs/001-folio-creation-general-info/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Creación de Folio y Captura de Datos Generales
+
+**Purpose**: Validar completitud y calidad de la spec antes de pasar a planning
+**Created**: 2026-04-24
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] Sin detalles de implementación (lenguajes, frameworks, APIs)
+- [x] Enfocado en valor de usuario y necesidades de negocio
+- [x] Escrito para stakeholders no técnicos
+- [x] Todas las secciones obligatorias completadas
+
+## Requirement Completeness
+
+- [x] Sin marcadores [NEEDS CLARIFICATION] pendientes
+- [x] Requerimientos son testeables e inequívocos
+- [x] Criterios de éxito son medibles
+- [x] Criterios de éxito son agnósticos a tecnología
+- [x] Todos los acceptance scenarios están definidos
+- [x] Edge cases identificados
+- [x] Alcance claramente delimitado
+- [x] Dependencias y supuestos identificados
+
+## Feature Readiness
+
+- [x] Todos los requerimientos funcionales tienen criterios de aceptación claros
+- [x] User scenarios cubren el flujo principal
+- [x] La feature cumple los outcomes medibles definidos en Success Criteria
+- [x] Sin detalles de implementación en la especificación
+
+## Notes
+
+- Todos los ítems pasan. Spec lista para `/speckit.plan`.

--- a/specs/001-folio-creation-general-info/contracts/catalog-setup-api.md
+++ b/specs/001-folio-creation-general-info/contracts/catalog-setup-api.md
@@ -1,0 +1,75 @@
+# Contratos API — Setup de Catálogos (CatalogSetupHook)
+
+Estos endpoints son invocados por `CatalogSetupHook` en `@Before(order=1)`.
+No forman parte del flujo UI bajo prueba; son precondición de datos.
+
+**Base URL backend**: `http://localhost:8080` (`Constants.BACKEND_BASE_URL`)
+**Base URL core**: `http://localhost:8081` (`Constants.CORE_BASE_URL`)
+
+---
+
+## Suscriptores
+
+### GET /v1/subscribers
+Verifica que existe al menos un suscriptor en el catálogo.
+
+**Response exitosa (200)**:
+```json
+[
+  { "id": "SUB-001", "name": "Aseguradora Norte" }
+]
+```
+
+**Acción del hook**: si el arreglo está vacío → invocar POST /v1/subscribers.
+
+### POST /v1/subscribers *(solo si catálogo vacío)*
+Crea un suscriptor mínimo de prueba.
+
+**Request**:
+```json
+{ "id": "SUB-TEST", "name": "Suscriptor Automatización" }
+```
+
+**Response exitosa (201)**:
+```json
+{ "id": "SUB-TEST", "name": "Suscriptor Automatización" }
+```
+
+---
+
+## Agentes
+
+### GET /v1/agents
+Verifica que existe al menos un agente en el catálogo.
+
+**Response exitosa (200)**:
+```json
+[
+  { "code": "AGT-001", "name": "Agente Prueba" }
+]
+```
+
+**Acción del hook**: si el arreglo está vacío → invocar POST /v1/agents.
+
+### POST /v1/agents *(solo si catálogo vacío)*
+Crea un agente mínimo de prueba.
+
+**Request**:
+```json
+{ "code": "AGT-TEST", "name": "Agente Automatización" }
+```
+
+**Response exitosa (201)**:
+```json
+{ "code": "AGT-TEST", "name": "Agente Automatización" }
+```
+
+---
+
+## Notas
+
+- Si cualquier llamada retorna un código fuera del rango 2xx, el hook lanza
+  excepción y el escenario falla con error de precondición.
+- Los datos creados por el hook son de prueba; no representan datos reales
+  del negocio.
+- Los valores de los campos de prueba están definidos en `Constants.java`.

--- a/specs/001-folio-creation-general-info/data-model.md
+++ b/specs/001-folio-creation-general-info/data-model.md
@@ -1,0 +1,67 @@
+# Data Model: Creación de Folio y Captura de Datos Generales
+
+**Branch**: `001-folio-creation-general-info` | **Date**: 2026-04-24
+
+## Estado de sesión del Actor
+
+El Actor mantiene estado entre steps mediante `actor.remember` / `actor.recall`.
+No se usan variables estáticas ni campos de instancia (principio V).
+
+| Clave | Tipo | Producido por | Consumido por |
+|-------|------|---------------|---------------|
+| `"folioNumber"` | `String` | `CreateFolio` (Task UI) | Steps siguientes; flows 002 y 003 |
+
+## Datos de prueba (en Constants.java)
+
+Valores fijos usados por `CompleteGeneralInfo` Task:
+
+| Constante | Valor de ejemplo | Usado en |
+|-----------|------------------|----------|
+| `TEST_RAZON_SOCIAL` | `"Empresa Prueba SA de CV"` | campo Razón social |
+| `TEST_RFC` | `"EPR860101AB2"` | campo RFC |
+| `TEST_EMAIL` | `"prueba@automation.com"` | campo Correo de contacto |
+| `TEST_PHONE` | `"5512345678"` | campo Teléfono |
+
+## Entidades del sistema bajo prueba
+
+### Folio
+Identificador único de cotización. Generado por el backend al invocar `POST /v1/folios`.
+
+| Atributo | Tipo | Observabilidad en UI |
+|----------|------|----------------------|
+| `folioNumber` | `String` (ej. `FOL-2026-00003`) | URL activa + breadcrumb |
+| `status` | `String` (ej. `Creado`) | badge de estado en dashboard |
+
+### DatosAsegurado
+Sección "Asegurado" del paso 1 del wizard.
+
+| Campo UI | Tipo | Obligatorio |
+|----------|------|-------------|
+| Razón social | texto | sí |
+| RFC | texto | sí |
+| Correo de contacto | email | sí |
+| Teléfono | texto | sí |
+
+### DatosSuscripcion
+Sección "Suscripción" del paso 1 del wizard.
+
+| Campo UI | Tipo | Origen |
+|----------|------|--------|
+| Suscriptor | dropdown (catálogo) | precargado del modal de creación |
+| Agente | dropdown (catálogo) | precargado del modal de creación |
+| Clasificación de riesgo | dropdown (catálogo) | selección en esta pantalla |
+| Tipo de negocio | dropdown (catálogo) | selección en esta pantalla |
+
+## Clases Java del proyecto (no son entidades de dominio)
+
+| Clase | Tipo | Propósito |
+|-------|------|-----------|
+| `CreateFolio` | Task UI | abre modal, selecciona suscriptor y agente, confirma |
+| `CompleteGeneralInfo` | Task UI | llena datos asegurado y suscripción, avanza |
+| `CatalogSetupHook` | Hook | verifica/crea catálogos mínimos vía API @Before(order=1) |
+| `SectionCompletionStatus` | Question\<List\<String\>\> | badges "• Completo" visibles |
+| `WizardStepIndicator` | Question\<String\> | paso activo en el stepper |
+| `DashboardTargets` | Targets | localizadores de la página `/cotizador` |
+| `GeneralInfoTargets` | Targets | localizadores del paso 1 del wizard |
+| `Constants` | Utility | todos los valores literales del proyecto |
+| `FolioTestRunner` | Runner | JUnit Suite para este feature |

--- a/specs/001-folio-creation-general-info/plan.md
+++ b/specs/001-folio-creation-general-info/plan.md
@@ -1,0 +1,144 @@
+# Implementation Plan: Creación de Folio y Captura de Datos Generales
+
+**Branch**: `001-folio-creation-general-info` | **Date**: 2026-04-24 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `specs/001-folio-creation-general-info/spec.md`
+
+## Summary
+
+Implementar el primer flujo de automatización UI del cotizador: creación de folio
+desde el dashboard mediante el modal de "+ Nuevo folio" y completado de los datos
+generales del asegurado y la suscripción en el paso 1 del wizard. El escenario
+verifica que ambas secciones muestran estado completo y el wizard avanza al layout.
+
+## Technical Context
+
+**Language/Version**: Java 21
+**Primary Dependencies**: Serenity BDD 4.2.34, serenity-screenplay-webdriver 4.2.34,
+Selenium 4.33.0, Cucumber 7.22.2, AssertJ 3.27.3
+**Storage**: N/A
+**Testing**: N/A (principio IX — sin pruebas sobre el código de automatización)
+**Target Platform**: JVM + Chrome browser, SUT en http://localhost:4200
+**Project Type**: UI test automation (Screenplay pattern)
+**Performance Goals**: N/A
+**Constraints**: Versiones fijadas por constitución; máximo 5 steps Gherkin; sin Thread.sleep
+**Scale/Scope**: 1 feature file, 1 escenario, 2 Tasks UI, 1 Hook, 2 Questions, 2 Target classes
+
+## Constitution Check
+
+*GATE: Debe pasar antes de iniciar la implementación.*
+
+| Principio | Estado | Evidencia |
+|-----------|--------|-----------|
+| I. Screenplay Pattern | ✅ PASS | `CreateFolio` + `CompleteGeneralInfo` implementan `Performable`; `SectionCompletionStatus` + `WizardStepIndicator` implementan `Question<T>`; localizadores en `DashboardTargets` y `GeneralInfoTargets` |
+| II. Bounded Scope | ✅ PASS | Flow 001 dentro del alcance de 3 flujos definidos; sin POM |
+| III. Declarative Gherkin | ✅ PASS | 4 steps en español, lenguaje de negocio, sin referencias técnicas |
+| IV. Test Data Independence | ✅ PASS | `CatalogSetupHook` @Before(order=1); folio creado por UI (comportamiento bajo prueba) |
+| V. Separation of Concerns | ✅ PASS | StepDefs orquestan; Tasks actúan en UI; Questions extraen estado |
+| VI. Language Convention | ✅ PASS | Código Java en inglés; Gherkin y docs en español |
+| VII. No Hardcoding | ✅ PASS | Todos los valores de prueba en `Constants.java` |
+| VIII. GitFlow | ✅ PASS | Feature branch desde develop, merge vía PR |
+| IX. No Self-Testing | ✅ PASS | Sin clases de test sobre Tasks ni Questions |
+| X. Pinned Dependencies | ✅ PASS | Versiones exactas según constitución |
+| XI. No Overengineering | ✅ PASS | 2 Tasks, 2 Questions, 2 Target classes — mínimo necesario |
+
+## Project Structure
+
+### Documentación (este feature)
+
+```text
+specs/001-folio-creation-general-info/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── catalog-setup-api.md
+└── checklists/
+    └── requirements.md
+```
+
+### Código fuente (raíz del repositorio)
+
+```text
+build.gradle
+settings.gradle
+serenity.conf
+src/test/
+├── java/com/sofka/automation/
+│   ├── hooks/
+│   │   └── CatalogSetupHook.java
+│   ├── tasks/
+│   │   └── ui/
+│   │       ├── CreateFolio.java
+│   │       └── CompleteGeneralInfo.java
+│   ├── questions/
+│   │   ├── SectionCompletionStatus.java
+│   │   └── WizardStepIndicator.java
+│   ├── targets/
+│   │   ├── DashboardTargets.java
+│   │   └── GeneralInfoTargets.java
+│   ├── stepdefinitions/
+│   │   └── FolioCreationStepDefinitions.java
+│   ├── runners/
+│   │   └── FolioTestRunner.java
+│   └── utils/
+│       └── Constants.java
+└── resources/
+    ├── features/
+    │   └── folio_creation_general_info.feature
+    └── serenity.conf
+```
+
+## Decisiones de diseño
+
+**CreateFolio Task**:
+- Navega a `Constants.BASE_URL` si no está en el dashboard.
+- Clic en "+ Nuevo folio" (`DashboardTargets.NEW_FOLIO_BUTTON`).
+- Espera a que el modal sea visible.
+- Selecciona primer elemento de Suscriptor (`DashboardTargets.SUBSCRIBER_DROPDOWN`).
+- Selecciona primer elemento de Agente (`DashboardTargets.AGENT_DROPDOWN`).
+- Clic en "Crear folio" (`DashboardTargets.CREATE_FOLIO_BUTTON`).
+- Extrae folioNumber de URL activa vía `TheWebPage.currentUrl()`.
+- Llama `actor.remember("folioNumber", folioNumber)`.
+
+**CompleteGeneralInfo Task**:
+- Llena Razón social con `Constants.TEST_RAZON_SOCIAL`.
+- Llena RFC con `Constants.TEST_RFC`.
+- Llena Correo con `Constants.TEST_EMAIL`.
+- Llena Teléfono con `Constants.TEST_PHONE`.
+- Selecciona primera opción de Clasificación de riesgo.
+- Selecciona primera opción de Tipo de negocio.
+- Clic en "Siguiente →" (`GeneralInfoTargets.NEXT_BUTTON`).
+
+**SectionCompletionStatus Question**:
+- Retorna `List<String>` con nombres de secciones que muestran badge "• Completo".
+- Assertion verifica que contiene "Asegurado" y "Suscripción".
+
+**WizardStepIndicator Question**:
+- Retorna texto del paso activo en el stepper.
+- Assertion verifica que contiene "Layout".
+
+**CatalogSetupHook**:
+- `@Before(order=1)` global para todos los escenarios del proyecto.
+- `GET /v1/subscribers` → vacío → `POST /v1/subscribers` con datos de `Constants`.
+- `GET /v1/agents` → vacío → `POST /v1/agents` con datos de `Constants`.
+- Usa RestAssured directamente (sin Screenplay WebDriver).
+
+**FolioTestRunner**:
+- `@Suite` + `@IncludeEngines("cucumber")`.
+- `@SelectClasspathResource("features/folio_creation_general_info.feature")`.
+- Plugin: `io.cucumber.core.plugin.SerenityReporterParallel`.
+
+**serenity.conf**:
+```
+webdriver.driver = chrome
+serenity.base.url = "http://localhost:4200"
+restapi.base.url = "http://localhost:8080"
+```
+
+**build.gradle**: plugin 4.2.34, dependencias de constitución, task `test` finalizada por `aggregate`.
+
+## Complexity Tracking
+
+> Sin violaciones a la constitución. No aplica.

--- a/specs/001-folio-creation-general-info/quickstart.md
+++ b/specs/001-folio-creation-general-info/quickstart.md
@@ -1,0 +1,52 @@
+# Quickstart: Creación de Folio y Captura de Datos Generales
+
+## Requisitos previos
+
+| Requisito | Verificación |
+|-----------|-------------|
+| Java 21 | `java -version` |
+| Google Chrome (última versión estable) | `google-chrome --version` |
+| Backend corriendo en `http://localhost:8080` | `curl http://localhost:8080/actuator/health` |
+| Core corriendo en `http://localhost:8081` | `curl http://localhost:8081/actuator/health` |
+| SPA corriendo en `http://localhost:4200` | abrir en browser |
+
+## Ejecutar el escenario
+
+Desde la raíz del proyecto `Insurance_Quoter_Auto_Front_Screenplay/`:
+
+```bash
+./gradlew clean test aggregate
+```
+
+El hook `@Before` verifica y crea catálogos automáticamente antes de que
+arranque el escenario. No se requieren seeds manuales.
+
+## Ver el reporte
+
+```bash
+# El reporte se genera en:
+target/site/serenity/index.html
+
+# Abrir en macOS:
+open target/site/serenity/index.html
+
+# Abrir en Windows:
+start target/site/serenity/index.html
+```
+
+## Ejecutar solo este feature
+
+```bash
+./gradlew clean test aggregate -Dcucumber.filter.tags="@folio-creation"
+```
+
+Agregar el tag `@folio-creation` en el archivo `.feature` para filtrar.
+
+## Troubleshooting
+
+| Síntoma | Causa probable | Solución |
+|---------|----------------|----------|
+| `CatalogSetupHook` falla con 4xx | backend no responde o endpoint no existe | verificar que backend está corriendo |
+| `NoSuchElementException` en modal | SPA no cargó a tiempo | revisar `webdriver.timeouts.implicitlywait` en `serenity.conf` |
+| Folio no extraído de URL | redirección tardía del Angular router | aumentar `webdriver.timeouts.pageLoadTimeout` |
+| ChromeDriver incompatible | versión de Chrome actualizada | Selenium 4.33.0 usa ChromeDriver Manager automático |

--- a/specs/001-folio-creation-general-info/research.md
+++ b/specs/001-folio-creation-general-info/research.md
@@ -1,0 +1,62 @@
+# Research: Creación de Folio y Captura de Datos Generales
+
+**Branch**: `001-folio-creation-general-info` | **Date**: 2026-04-24
+
+## Decisiones técnicas
+
+### 1. Estrategia de esperas en WebDriver
+
+**Decisión**: Esperas implícitas de Serenity WebDriver (configuradas en `serenity.conf`).
+
+**Rationale**: Serenity gestiona el ciclo de vida del driver y aplica esperas automáticas
+antes de interactuar con elementos. Elimina `Thread.sleep` (prohibido por constitución,
+principio XI) y evita la fragilidad de timeouts hardcodeados.
+
+**Alternativas descartadas**:
+- `WebDriverWait` explícita: válida pero verbosa; Serenity ya la abstrae.
+- `Thread.sleep`: prohibida por constitución.
+
+### 2. Extracción del número de folio tras creación
+
+**Decisión**: Extraer el folio de la URL activa después de que el modal cierre y el
+wizard redirija (`driver.getCurrentUrl()` vía `TheWebPage.currentUrl()`).
+
+**Rationale**: La URL contiene el folioNumber directamente (ej. `/quotes/FOL-2026-00003/general-info`).
+Es más estable que buscar el folio en el DOM, que puede estar en múltiples componentes.
+
+**Alternativas descartadas**:
+- Leer el folio de un elemento DOM: frágil si el diseño del componente cambia.
+
+### 3. Selección de elementos en dropdowns de catálogo
+
+**Decisión**: Seleccionar el primer elemento disponible en los dropdowns de Suscriptor
+y Agente (no buscar un valor específico por nombre).
+
+**Rationale**: El hook `@Before` garantiza que existe al menos un elemento; seleccionar
+el primero disponible hace el test independiente de qué catálogos específicos existan
+en el ambiente.
+
+**Alternativas descartadas**:
+- Seleccionar por valor fijo en `Constants.java`: acoplamiento al dato concreto que puede
+  no existir en todos los ambientes.
+
+### 4. Setup de catálogos en hook @Before
+
+**Decisión**: `CatalogSetupHook` llama a `GET /v1/subscribers` y `GET /v1/agents`. Si
+la respuesta está vacía, llama a `POST` para crear registros mínimos con datos de
+`Constants.java`.
+
+**Rationale**: Garantiza independencia de datos (principio IV de constitución) sin
+requerir seeds manuales en la BD antes de cada ejecución.
+
+**Alternativas descartadas**:
+- Fixtures de BD directa (SQL scripts): acoplamiento al motor de BD y requiere acceso
+  directo a la instancia.
+- Asumir datos preexistentes: violación directa de principio IV.
+
+### 5. Paquete base del proyecto
+
+**Decisión**: `com.sofka.automation`
+
+**Rationale**: Consistencia con la convención de la organización (Sofka) y el proyecto
+(automation).

--- a/specs/001-folio-creation-general-info/spec.md
+++ b/specs/001-folio-creation-general-info/spec.md
@@ -1,0 +1,104 @@
+# Feature Specification: Creación de Folio y Captura de Datos Generales
+
+**Feature Branch**: `001-folio-creation-general-info`
+**Created**: 2026-04-24
+**Status**: Draft
+**Input**: Automatización del flujo de creación de folio y captura de datos generales en la SPA cotizador-danos-web.
+
+## User Scenarios & Testing *(mandatory)*
+
+### HU-FRONT-01 — Creación de folio y registro de datos generales (Priority: P1)
+
+Como agente del cotizador,
+quiero crear un nuevo folio seleccionando suscriptor y agente, y completar
+los datos del asegurado y la suscripción,
+para iniciar una cotización con toda la información general registrada.
+
+**Why this priority**: Es el punto de entrada obligatorio de toda cotización.
+Sin folio creado y datos generales completos, ningún paso posterior del wizard
+(layout, ubicaciones, coberturas, cálculo) puede ejecutarse.
+
+**Independent Test**: El escenario es autónomo — crea su propio folio desde
+el dashboard y verifica que ambas secciones muestran estado completo al finalizar.
+No depende de datos preexistentes más allá de los catálogos mínimos garantizados
+por el hook `@Before`.
+
+**Acceptance Scenarios**:
+
+1. **Given** el agente está en el panel de cotizaciones,
+   **When** crea un nuevo folio con un suscriptor y agente disponibles,
+   **Then** el sistema genera un número de folio único y muestra el paso 1 del wizard.
+
+2. **Given** el folio fue creado y el wizard muestra el paso de datos generales,
+   **When** el agente completa los datos del asegurado y la suscripción,
+   **Then** ambas secciones muestran estado completo y el wizard permite avanzar al layout.
+
+---
+
+### Edge Cases
+
+- ¿Qué sucede si los catálogos de suscriptores o agentes están vacíos?
+  El hook `@Before` garantiza al menos un elemento en cada catálogo antes
+  de que arranque el escenario; si falla el hook, el escenario falla con
+  error de precondición, no de UI.
+- ¿Qué sucede si el backend no responde al crear el folio?
+  El escenario falla con error de conexión; no se requiere reintento automático.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: La automatización MUST navegar al dashboard del cotizador
+  (`/cotizador`) y verificar que el panel de folios está visible.
+- **FR-002**: La automatización MUST abrir el modal de creación de folio,
+  seleccionar el primer suscriptor disponible en el catálogo y el primer
+  agente disponible, y confirmar la creación.
+- **FR-003**: El número de folio generado MUST capturarse y almacenarse en
+  la sesión del actor (`actor.remember("folioNumber")`) para propagación
+  entre steps.
+- **FR-004**: La automatización MUST completar la sección "Asegurado" con
+  valores válidos: razón social, RFC, correo de contacto y teléfono.
+- **FR-005**: La automatización MUST completar la sección "Suscripción"
+  seleccionando clasificación de riesgo y tipo de negocio de los catálogos.
+- **FR-006**: La automatización MUST verificar que ambas secciones muestran
+  el badge de estado completo antes de avanzar.
+- **FR-007**: La automatización MUST avanzar al siguiente paso del wizard
+  y verificar que el stepper indica el paso de Layout activo.
+
+### Key Entities
+
+- **Folio**: identificador único de cotización generado por el sistema
+  (formato `FOL-YYYY-NNNNN`). Atributos relevantes: `folioNumber`.
+- **DatosAsegurado**: razón social, RFC, correo de contacto, teléfono.
+- **DatosSuscripcion**: suscriptor (precargado del modal), agente (precargado
+  del modal), clasificación de riesgo, tipo de negocio.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: El escenario completo se ejecuta de principio a fin sin errores
+  cuando el backend y el core están disponibles.
+- **SC-002**: El número de folio generado es no vacío y sigue el formato
+  esperado (`FOL-YYYY-NNNNN`).
+- **SC-003**: Ambas secciones (Asegurado y Suscripción) muestran badge de
+  estado completo al finalizar el step de datos generales.
+- **SC-004**: El reporte Serenity muestra el resultado del escenario con
+  detalle paso a paso y capturas de pantalla.
+- **SC-005**: El escenario no depende de estado previo en la base de datos
+  más allá de los catálogos garantizados por el hook `@Before`.
+
+## Assumptions
+
+- El backend (`http://localhost:8080`) y el core (`http://localhost:8081`)
+  están corriendo antes de ejecutar la automatización.
+- El hook `@Before(order=1)` garantiza al menos 1 suscriptor y 1 agente en
+  los catálogos antes de que arranque el escenario.
+- Los valores de prueba para la sección "Asegurado" son fijos (hardcoded en
+  `Constants.java`): razón social, RFC, correo y teléfono de ejemplo.
+- No se requiere autenticación para acceder a la aplicación.
+- El folio se crea por UI en este escenario porque eso es el comportamiento
+  que se está probando; flows 002 y 003 reutilizan esta cobertura y crean el
+  folio por API en su setup.
+- El wizard avanza automáticamente al paso de Layout al hacer clic en
+  "Siguiente →" con todas las secciones completas.

--- a/specs/001-folio-creation-general-info/tasks.md
+++ b/specs/001-folio-creation-general-info/tasks.md
@@ -1,0 +1,148 @@
+# Tasks: Creación de Folio y Captura de Datos Generales
+
+**Input**: Design documents from `specs/001-folio-creation-general-info/`
+**Prerequisites**: plan.md ✅, spec.md ✅, research.md ✅, data-model.md ✅, contracts/ ✅
+
+**Tests**: No incluidas (principio IX de constitución — sin pruebas unitarias sobre código de automatización).
+
+**Organization**: Tareas agrupadas por historia de usuario para implementación independiente.
+
+---
+
+## Phase 1: Setup (Infraestructura compartida)
+
+**Purpose**: Inicialización del proyecto y estructura base. Sin estas tareas ninguna otra puede ejecutarse.
+
+- [ ] T001 Crear `build.gradle` con plugin `net.serenity-bdd.serenity-gradle-plugin:4.2.34`, dependencias fijadas por constitución (serenity-core, serenity-cucumber, serenity-screenplay, serenity-screenplay-webdriver 4.2.34; selenium-java 4.33.0; cucumber-junit-platform-engine 7.22.2; junit-platform-suite 1.12.2; junit-jupiter 5.12.2; assertj-core 3.27.3), Java toolchain 21, task `test` finalizada por `aggregate`
+- [ ] T002 Crear `settings.gradle` con `rootProject.name = 'Insurance_Quoter_Auto_Front_Screenplay'`
+- [ ] T003 Crear `src/test/resources/serenity.conf` con `webdriver.driver = chrome`, `serenity.base.url = "http://localhost:4200"`, `restapi.base.url = "http://localhost:8080"`, `serenity.project.name`, `serenity.reports = ["single-page-html"]`
+- [ ] T004 [P] Crear estructura de directorios vacía: `src/test/java/com/sofka/automation/hooks/`, `tasks/ui/`, `tasks/api/`, `questions/`, `targets/`, `stepdefinitions/`, `runners/`, `utils/`; `src/test/resources/features/`
+
+**Checkpoint**: Proyecto compila con `./gradlew clean test` (aunque falle por falta de features).
+
+---
+
+## Phase 2: Foundational (Prerequisitos bloqueantes)
+
+**Purpose**: Infraestructura core que DEBE completarse antes de implementar HU-FRONT-01.
+
+⚠️ CRITICAL: No iniciar Phase 3 hasta completar esta fase.
+
+- [ ] T005 Crear `src/test/java/com/sofka/automation/utils/Constants.java` con todas las constantes del proyecto: `BASE_URL = "http://localhost:4200"`, `BACKEND_BASE_URL = "http://localhost:8080"`, `CORE_BASE_URL = "http://localhost:8081"`, `TEST_RAZON_SOCIAL = "Empresa Prueba SA de CV"`, `TEST_RFC = "EPR860101AB2"`, `TEST_EMAIL = "prueba@automation.com"`, `TEST_PHONE = "5512345678"`, `TEST_SUBSCRIBER_ID = "SUB-TEST"`, `TEST_SUBSCRIBER_NAME = "Suscriptor Automatización"`, `TEST_AGENT_CODE = "AGT-TEST"`, `TEST_AGENT_NAME = "Agente Automatización"`
+- [ ] T006 Crear `src/test/java/com/sofka/automation/hooks/CatalogSetupHook.java` con `@Before(order=1)`: GET `/v1/subscribers` vía RestAssured usando `Constants.BACKEND_BASE_URL`; si respuesta vacía → POST con datos de Constants; misma lógica para GET/POST `/v1/agents`; lanzar excepción si cualquier llamada retorna código fuera de 2xx
+- [ ] T007 Crear `src/test/resources/features/folio_creation_general_info.feature` con `# language: es`, `Característica: Creación de folio y captura de datos generales`, escenario único con 4 steps declarativos en español (Dado/Cuando/Y/Entonces) según acceptance scenarios de spec.md HU-FRONT-01
+- [ ] T008 Crear `src/test/java/com/sofka/automation/runners/FolioTestRunner.java` con `@Suite`, `@IncludeEngines("cucumber")`, `@SelectClasspathResource("features/folio_creation_general_info.feature")`, `@ConfigurationParameter` para glue path `com.sofka.automation.stepdefinitions` y plugin `io.cucumber.core.plugin.SerenityReporterParallel`
+
+**Checkpoint**: Proyecto compila y el runner encuentra el feature file (el escenario falla por falta de step definitions — esperado).
+
+---
+
+## Phase 3: HU-FRONT-01 — Creación de Folio y Datos Generales (Priority: P1)
+
+**Goal**: Implementar el escenario completo de creación de folio y captura de datos generales verificando badge de estado completo en ambas secciones.
+
+**Independent Test**: Ejecutar `./gradlew clean test aggregate`. El escenario debe pasar de principio a fin con backend y core corriendo. El hook `@Before` garantiza catálogos; el escenario crea su propio folio por UI.
+
+### Targets (localizadores — implementar primero, en paralelo)
+
+- [ ] T009 [P] [US1] Crear `src/test/java/com/sofka/automation/targets/DashboardTargets.java` con constantes `Target`: `NEW_FOLIO_BUTTON` (botón "+ Nuevo folio"), `SUBSCRIBER_DROPDOWN` (dropdown Suscriptor en modal), `SUBSCRIBER_FIRST_OPTION` (primera opción del dropdown Suscriptor), `AGENT_DROPDOWN` (dropdown Agente en modal), `AGENT_FIRST_OPTION` (primera opción del dropdown Agente), `CREATE_FOLIO_BUTTON` (botón "Crear folio" del modal) — leer HTML del frontend en `D:\Trabajo\Sofka\Insurance-Quoter\Insurance-Quoter\Insurance-Quoter-Front\` para obtener selectores CSS/atributos reales
+- [ ] T010 [P] [US1] Crear `src/test/java/com/sofka/automation/targets/GeneralInfoTargets.java` con constantes `Target`: `RAZON_SOCIAL_INPUT`, `RFC_INPUT`, `EMAIL_INPUT`, `PHONE_INPUT`, `RISK_CLASSIFICATION_DROPDOWN`, `RISK_CLASSIFICATION_FIRST_OPTION`, `BUSINESS_TYPE_DROPDOWN`, `BUSINESS_TYPE_FIRST_OPTION`, `NEXT_BUTTON` (botón "Siguiente →"), `SECTION_COMPLETE_BADGE` (badge "• Completo"), `WIZARD_ACTIVE_STEP` (paso activo en stepper) — leer HTML del frontend para selectores reales
+
+### Questions (en paralelo, dependen de Targets)
+
+- [ ] T011 [P] [US1] Crear `src/test/java/com/sofka/automation/questions/SectionCompletionStatus.java` implementando `Question<List<String>>`: localiza todos los elementos `GeneralInfoTargets.SECTION_COMPLETE_BADGE` visibles y retorna lista con el texto/nombre de cada sección que muestra el badge
+- [ ] T012 [P] [US1] Crear `src/test/java/com/sofka/automation/questions/WizardStepIndicator.java` implementando `Question<String>`: localiza `GeneralInfoTargets.WIZARD_ACTIVE_STEP` y retorna su texto (nombre del paso activo)
+
+### Tasks UI (en paralelo, dependen de Targets)
+
+- [ ] T013 [P] [US1] Crear `src/test/java/com/sofka/automation/tasks/ui/CreateFolio.java` implementando `Performable`: navegar a `Constants.BASE_URL`; hacer clic en `DashboardTargets.NEW_FOLIO_BUTTON`; seleccionar `DashboardTargets.SUBSCRIBER_FIRST_OPTION`; seleccionar `DashboardTargets.AGENT_FIRST_OPTION`; hacer clic en `DashboardTargets.CREATE_FOLIO_BUTTON`; extraer folioNumber de la URL activa con `TheWebPage.currentUrl()` mediante regex sobre el patrón `FOL-\d{4}-\d+`; llamar `actor.remember("folioNumber", folioNumber)`
+- [ ] T014 [P] [US1] Crear `src/test/java/com/sofka/automation/tasks/ui/CompleteGeneralInfo.java` implementando `Performable`: introducir `Constants.TEST_RAZON_SOCIAL` en `GeneralInfoTargets.RAZON_SOCIAL_INPUT`; introducir `Constants.TEST_RFC` en `GeneralInfoTargets.RFC_INPUT`; introducir `Constants.TEST_EMAIL` en `GeneralInfoTargets.EMAIL_INPUT`; introducir `Constants.TEST_PHONE` en `GeneralInfoTargets.PHONE_INPUT`; seleccionar `GeneralInfoTargets.RISK_CLASSIFICATION_FIRST_OPTION`; seleccionar `GeneralInfoTargets.BUSINESS_TYPE_FIRST_OPTION`; hacer clic en `GeneralInfoTargets.NEXT_BUTTON`
+
+### Step Definitions (bloqueante — depende de T009–T014)
+
+- [ ] T015 [US1] Crear `src/test/java/com/sofka/automation/stepdefinitions/FolioCreationStepDefinitions.java`: implementar los 4 steps del feature file usando `OnStage.theActorCalled("Agente")`; step "está en el panel" → `actor.attemptsTo(NavigateTo.thePageAt(Constants.BASE_URL))`; step "crea un nuevo folio" → `actor.attemptsTo(CreateFolio.fromDashboard())`; step "completa los datos" → `actor.attemptsTo(CompleteGeneralInfo.withDefaultTestData())`; step "ambas secciones muestran estado completo" → `assertThat(actor.asksAbout(SectionCompletionStatus.forBothSections())).contains("Asegurado", "Suscripción")`; step "folio avanza al paso de layout" → `assertThat(actor.asksAbout(WizardStepIndicator.currentStep())).containsIgnoringCase("Layout")`
+
+**Checkpoint**: `./gradlew clean test aggregate` ejecuta el escenario completo sin errores. Reporte en `target/site/serenity/`.
+
+---
+
+## Phase N: Polish & Cross-Cutting Concerns
+
+- [ ] T016 [P] Crear `README.md` en raíz con: requisitos previos, comando de ejecución `./gradlew clean test aggregate`, ubicación del reporte, configuración del browser, estructura del proyecto
+- [ ] T017 Validar ejecución end-to-end siguiendo `specs/001-folio-creation-general-info/quickstart.md`: verificar que todos los SC-001 a SC-005 pasan, reporte Serenity generado con capturas por step
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 (Setup)**: Sin dependencias — iniciar inmediatamente
+- **Phase 2 (Foundational)**: Depende de Phase 1 completa — BLOQUEA Phase 3
+- **Phase 3 (HU-FRONT-01)**: Depende de Phase 2 completa
+  - T009, T010 (Targets): en paralelo, sin dependencias entre sí
+  - T011, T012 (Questions): en paralelo, dependen de Targets correspondientes
+  - T013, T014 (Tasks UI): en paralelo, dependen de Targets correspondientes
+  - T015 (StepDefinitions): bloqueante en T009–T014 todos completos
+- **Phase N (Polish)**: Depende de Phase 3 completa
+
+### Within HU-FRONT-01
+
+Targets → Questions & Tasks UI (en paralelo) → StepDefinitions → validación
+
+### Parallel Opportunities
+
+```bash
+# Phase 2 — en paralelo (archivos distintos):
+T005 Constants.java
+T006 CatalogSetupHook.java
+T007 folio_creation_general_info.feature
+T008 FolioTestRunner.java
+
+# Phase 3 — en paralelo tras Phase 2:
+T009 DashboardTargets.java
+T010 GeneralInfoTargets.java
+T011 SectionCompletionStatus.java  # tras T010
+T012 WizardStepIndicator.java      # tras T010
+T013 CreateFolio.java              # tras T009
+T014 CompleteGeneralInfo.java      # tras T010
+# T015 FolioCreationStepDefinitions.java — bloquea en T009–T014
+```
+
+---
+
+## Implementation Strategy
+
+### MVP (HU-FRONT-01 único)
+
+1. Phase 1: Setup
+2. Phase 2: Foundational (CRÍTICO — bloquea todo)
+3. Phase 3: HU-FRONT-01
+4. **STOP y VALIDAR**: `./gradlew clean test aggregate` — escenario pasa end-to-end
+5. Polish: README + quickstart validation
+
+---
+
+## Summary
+
+| Métrica | Valor |
+|---------|-------|
+| Total tareas | 17 |
+| Phase 1 Setup | T001–T004 (4 tareas) |
+| Phase 2 Foundational | T005–T008 (4 tareas) |
+| Phase 3 HU-FRONT-01 | T009–T015 (7 tareas) |
+| Phase N Polish | T016–T017 (2 tareas) |
+| Oportunidades paralelo | T004, T005–T008, T009–T014 |
+| Tests incluidas | Ninguna (principio IX) |
+| MVP scope | Phase 1 + 2 + 3 completas |
+
+---
+
+## Notes
+
+- `[P]` = archivos distintos, sin dependencias — ejecutar en paralelo
+- `[US1]` mapea a HU-FRONT-01 en spec.md
+- Sin tests unitarios (principio IX de constitución)
+- Leer HTML de `D:\Trabajo\Sofka\Insurance-Quoter\Insurance-Quoter\Insurance-Quoter-Front\` para selectores CSS reales en T009 y T010
+- Todos los valores literales en `Constants.java` (T005) — ningún valor hardcoded en otras clases
+- Commit después de cada fase completada siguiendo Conventional Commits

--- a/specs/001-folio-creation-general-info/tasks.md
+++ b/specs/001-folio-creation-general-info/tasks.md
@@ -13,10 +13,10 @@
 
 **Purpose**: Inicialización del proyecto y estructura base. Sin estas tareas ninguna otra puede ejecutarse.
 
-- [ ] T001 Crear `build.gradle` con plugin `net.serenity-bdd.serenity-gradle-plugin:4.2.34`, dependencias fijadas por constitución (serenity-core, serenity-cucumber, serenity-screenplay, serenity-screenplay-webdriver 4.2.34; selenium-java 4.33.0; cucumber-junit-platform-engine 7.22.2; junit-platform-suite 1.12.2; junit-jupiter 5.12.2; assertj-core 3.27.3), Java toolchain 21, task `test` finalizada por `aggregate`
-- [ ] T002 Crear `settings.gradle` con `rootProject.name = 'Insurance_Quoter_Auto_Front_Screenplay'`
-- [ ] T003 Crear `src/test/resources/serenity.conf` con `webdriver.driver = chrome`, `serenity.base.url = "http://localhost:4200"`, `restapi.base.url = "http://localhost:8080"`, `serenity.project.name`, `serenity.reports = ["single-page-html"]`
-- [ ] T004 [P] Crear estructura de directorios vacía: `src/test/java/com/sofka/automation/hooks/`, `tasks/ui/`, `tasks/api/`, `questions/`, `targets/`, `stepdefinitions/`, `runners/`, `utils/`; `src/test/resources/features/`
+- [x] T001 Crear `build.gradle` con plugin `net.serenity-bdd.serenity-gradle-plugin:4.2.34`, dependencias fijadas por constitución (serenity-core, serenity-cucumber, serenity-screenplay, serenity-screenplay-webdriver 4.2.34; selenium-java 4.33.0; cucumber-junit-platform-engine 7.22.2; junit-platform-suite 1.12.2; junit-jupiter 5.12.2; assertj-core 3.27.3), Java toolchain 21, task `test` finalizada por `aggregate`
+- [x] T002 Crear `settings.gradle` con `rootProject.name = 'Insurance_Quoter_Auto_Front_Screenplay'`
+- [x] T003 Crear `src/test/resources/serenity.conf` con `webdriver.driver = chrome`, `serenity.base.url = "http://localhost:4200"`, `restapi.base.url = "http://localhost:8080"`, `serenity.project.name`, `serenity.reports = ["single-page-html"]`
+- [x] T004 [P] Crear estructura de directorios vacía: `src/test/java/com/sofka/automation/hooks/`, `tasks/ui/`, `tasks/api/`, `questions/`, `targets/`, `stepdefinitions/`, `runners/`, `utils/`; `src/test/resources/features/`
 
 **Checkpoint**: Proyecto compila con `./gradlew clean test` (aunque falle por falta de features).
 
@@ -28,10 +28,10 @@
 
 ⚠️ CRITICAL: No iniciar Phase 3 hasta completar esta fase.
 
-- [ ] T005 Crear `src/test/java/com/sofka/automation/utils/Constants.java` con todas las constantes del proyecto: `BASE_URL = "http://localhost:4200"`, `BACKEND_BASE_URL = "http://localhost:8080"`, `CORE_BASE_URL = "http://localhost:8081"`, `TEST_RAZON_SOCIAL = "Empresa Prueba SA de CV"`, `TEST_RFC = "EPR860101AB2"`, `TEST_EMAIL = "prueba@automation.com"`, `TEST_PHONE = "5512345678"`, `TEST_SUBSCRIBER_ID = "SUB-TEST"`, `TEST_SUBSCRIBER_NAME = "Suscriptor Automatización"`, `TEST_AGENT_CODE = "AGT-TEST"`, `TEST_AGENT_NAME = "Agente Automatización"`
-- [ ] T006 Crear `src/test/java/com/sofka/automation/hooks/CatalogSetupHook.java` con `@Before(order=1)`: GET `/v1/subscribers` vía RestAssured usando `Constants.BACKEND_BASE_URL`; si respuesta vacía → POST con datos de Constants; misma lógica para GET/POST `/v1/agents`; lanzar excepción si cualquier llamada retorna código fuera de 2xx
-- [ ] T007 Crear `src/test/resources/features/folio_creation_general_info.feature` con `# language: es`, `Característica: Creación de folio y captura de datos generales`, escenario único con 4 steps declarativos en español (Dado/Cuando/Y/Entonces) según acceptance scenarios de spec.md HU-FRONT-01
-- [ ] T008 Crear `src/test/java/com/sofka/automation/runners/FolioTestRunner.java` con `@Suite`, `@IncludeEngines("cucumber")`, `@SelectClasspathResource("features/folio_creation_general_info.feature")`, `@ConfigurationParameter` para glue path `com.sofka.automation.stepdefinitions` y plugin `io.cucumber.core.plugin.SerenityReporterParallel`
+- [x] T005 Crear `src/test/java/com/sofka/automation/utils/Constants.java` con todas las constantes del proyecto: `BASE_URL = "http://localhost:4200"`, `BACKEND_BASE_URL = "http://localhost:8080"`, `CORE_BASE_URL = "http://localhost:8081"`, `TEST_RAZON_SOCIAL = "Empresa Prueba SA de CV"`, `TEST_RFC = "EPR860101AB2"`, `TEST_EMAIL = "prueba@automation.com"`, `TEST_PHONE = "5512345678"`, `TEST_SUBSCRIBER_ID = "SUB-TEST"`, `TEST_SUBSCRIBER_NAME = "Suscriptor Automatización"`, `TEST_AGENT_CODE = "AGT-TEST"`, `TEST_AGENT_NAME = "Agente Automatización"`
+- [x] T006 Crear `src/test/java/com/sofka/automation/hooks/CatalogSetupHook.java` con `@Before(order=1)`: GET `/v1/subscribers` vía RestAssured usando `Constants.BACKEND_BASE_URL`; si respuesta vacía → POST con datos de Constants; misma lógica para GET/POST `/v1/agents`; lanzar excepción si cualquier llamada retorna código fuera de 2xx
+- [x] T007 Crear `src/test/resources/features/folio_creation_general_info.feature` con `# language: es`, `Característica: Creación de folio y captura de datos generales`, escenario único con 4 steps declarativos en español (Dado/Cuando/Y/Entonces) según acceptance scenarios de spec.md HU-FRONT-01
+- [x] T008 Crear `src/test/java/com/sofka/automation/runners/FolioTestRunner.java` con `@Suite`, `@IncludeEngines("cucumber")`, `@SelectClasspathResource("features/folio_creation_general_info.feature")`, `@ConfigurationParameter` para glue path `com.sofka.automation.stepdefinitions` y plugin `io.cucumber.core.plugin.SerenityReporterParallel`
 
 **Checkpoint**: Proyecto compila y el runner encuentra el feature file (el escenario falla por falta de step definitions — esperado).
 
@@ -45,22 +45,22 @@
 
 ### Targets (localizadores — implementar primero, en paralelo)
 
-- [ ] T009 [P] [US1] Crear `src/test/java/com/sofka/automation/targets/DashboardTargets.java` con constantes `Target`: `NEW_FOLIO_BUTTON` (botón "+ Nuevo folio"), `SUBSCRIBER_DROPDOWN` (dropdown Suscriptor en modal), `SUBSCRIBER_FIRST_OPTION` (primera opción del dropdown Suscriptor), `AGENT_DROPDOWN` (dropdown Agente en modal), `AGENT_FIRST_OPTION` (primera opción del dropdown Agente), `CREATE_FOLIO_BUTTON` (botón "Crear folio" del modal) — leer HTML del frontend en `D:\Trabajo\Sofka\Insurance-Quoter\Insurance-Quoter\Insurance-Quoter-Front\` para obtener selectores CSS/atributos reales
-- [ ] T010 [P] [US1] Crear `src/test/java/com/sofka/automation/targets/GeneralInfoTargets.java` con constantes `Target`: `RAZON_SOCIAL_INPUT`, `RFC_INPUT`, `EMAIL_INPUT`, `PHONE_INPUT`, `RISK_CLASSIFICATION_DROPDOWN`, `RISK_CLASSIFICATION_FIRST_OPTION`, `BUSINESS_TYPE_DROPDOWN`, `BUSINESS_TYPE_FIRST_OPTION`, `NEXT_BUTTON` (botón "Siguiente →"), `SECTION_COMPLETE_BADGE` (badge "• Completo"), `WIZARD_ACTIVE_STEP` (paso activo en stepper) — leer HTML del frontend para selectores reales
+- [x] T009 [P] [US1] Crear `src/test/java/com/sofka/automation/targets/DashboardTargets.java` con constantes `Target`: `NEW_FOLIO_BUTTON` (botón "+ Nuevo folio"), `SUBSCRIBER_DROPDOWN` (dropdown Suscriptor en modal), `SUBSCRIBER_FIRST_OPTION` (primera opción del dropdown Suscriptor), `AGENT_DROPDOWN` (dropdown Agente en modal), `AGENT_FIRST_OPTION` (primera opción del dropdown Agente), `CREATE_FOLIO_BUTTON` (botón "Crear folio" del modal) — leer HTML del frontend en `D:\Trabajo\Sofka\Insurance-Quoter\Insurance-Quoter\Insurance-Quoter-Front\` para obtener selectores CSS/atributos reales
+- [x] T010 [P] [US1] Crear `src/test/java/com/sofka/automation/targets/GeneralInfoTargets.java` con constantes `Target`: `RAZON_SOCIAL_INPUT`, `RFC_INPUT`, `EMAIL_INPUT`, `PHONE_INPUT`, `RISK_CLASSIFICATION_DROPDOWN`, `RISK_CLASSIFICATION_FIRST_OPTION`, `BUSINESS_TYPE_DROPDOWN`, `BUSINESS_TYPE_FIRST_OPTION`, `NEXT_BUTTON` (botón "Siguiente →"), `SECTION_COMPLETE_BADGE` (badge "• Completo"), `WIZARD_ACTIVE_STEP` (paso activo en stepper) — leer HTML del frontend para selectores reales
 
 ### Questions (en paralelo, dependen de Targets)
 
-- [ ] T011 [P] [US1] Crear `src/test/java/com/sofka/automation/questions/SectionCompletionStatus.java` implementando `Question<List<String>>`: localiza todos los elementos `GeneralInfoTargets.SECTION_COMPLETE_BADGE` visibles y retorna lista con el texto/nombre de cada sección que muestra el badge
-- [ ] T012 [P] [US1] Crear `src/test/java/com/sofka/automation/questions/WizardStepIndicator.java` implementando `Question<String>`: localiza `GeneralInfoTargets.WIZARD_ACTIVE_STEP` y retorna su texto (nombre del paso activo)
+- [x] T011 [P] [US1] Crear `src/test/java/com/sofka/automation/questions/SectionCompletionStatus.java` implementando `Question<List<String>>`: localiza todos los elementos `GeneralInfoTargets.SECTION_COMPLETE_BADGE` visibles y retorna lista con el texto/nombre de cada sección que muestra el badge
+- [x] T012 [P] [US1] Crear `src/test/java/com/sofka/automation/questions/WizardStepIndicator.java` implementando `Question<String>`: localiza `GeneralInfoTargets.WIZARD_ACTIVE_STEP` y retorna su texto (nombre del paso activo)
 
 ### Tasks UI (en paralelo, dependen de Targets)
 
-- [ ] T013 [P] [US1] Crear `src/test/java/com/sofka/automation/tasks/ui/CreateFolio.java` implementando `Performable`: navegar a `Constants.BASE_URL`; hacer clic en `DashboardTargets.NEW_FOLIO_BUTTON`; seleccionar `DashboardTargets.SUBSCRIBER_FIRST_OPTION`; seleccionar `DashboardTargets.AGENT_FIRST_OPTION`; hacer clic en `DashboardTargets.CREATE_FOLIO_BUTTON`; extraer folioNumber de la URL activa con `TheWebPage.currentUrl()` mediante regex sobre el patrón `FOL-\d{4}-\d+`; llamar `actor.remember("folioNumber", folioNumber)`
-- [ ] T014 [P] [US1] Crear `src/test/java/com/sofka/automation/tasks/ui/CompleteGeneralInfo.java` implementando `Performable`: introducir `Constants.TEST_RAZON_SOCIAL` en `GeneralInfoTargets.RAZON_SOCIAL_INPUT`; introducir `Constants.TEST_RFC` en `GeneralInfoTargets.RFC_INPUT`; introducir `Constants.TEST_EMAIL` en `GeneralInfoTargets.EMAIL_INPUT`; introducir `Constants.TEST_PHONE` en `GeneralInfoTargets.PHONE_INPUT`; seleccionar `GeneralInfoTargets.RISK_CLASSIFICATION_FIRST_OPTION`; seleccionar `GeneralInfoTargets.BUSINESS_TYPE_FIRST_OPTION`; hacer clic en `GeneralInfoTargets.NEXT_BUTTON`
+- [x] T013 [P] [US1] Crear `src/test/java/com/sofka/automation/tasks/ui/CreateFolio.java` implementando `Performable`: navegar a `Constants.BASE_URL`; hacer clic en `DashboardTargets.NEW_FOLIO_BUTTON`; seleccionar `DashboardTargets.SUBSCRIBER_FIRST_OPTION`; seleccionar `DashboardTargets.AGENT_FIRST_OPTION`; hacer clic en `DashboardTargets.CREATE_FOLIO_BUTTON`; extraer folioNumber de la URL activa con `TheWebPage.currentUrl()` mediante regex sobre el patrón `FOL-\d{4}-\d+`; llamar `actor.remember("folioNumber", folioNumber)`
+- [x] T014 [P] [US1] Crear `src/test/java/com/sofka/automation/tasks/ui/CompleteGeneralInfo.java` implementando `Performable`: introducir `Constants.TEST_RAZON_SOCIAL` en `GeneralInfoTargets.RAZON_SOCIAL_INPUT`; introducir `Constants.TEST_RFC` en `GeneralInfoTargets.RFC_INPUT`; introducir `Constants.TEST_EMAIL` en `GeneralInfoTargets.EMAIL_INPUT`; introducir `Constants.TEST_PHONE` en `GeneralInfoTargets.PHONE_INPUT`; seleccionar `GeneralInfoTargets.RISK_CLASSIFICATION_FIRST_OPTION`; seleccionar `GeneralInfoTargets.BUSINESS_TYPE_FIRST_OPTION`; hacer clic en `GeneralInfoTargets.NEXT_BUTTON`
 
 ### Step Definitions (bloqueante — depende de T009–T014)
 
-- [ ] T015 [US1] Crear `src/test/java/com/sofka/automation/stepdefinitions/FolioCreationStepDefinitions.java`: implementar los 4 steps del feature file usando `OnStage.theActorCalled("Agente")`; step "está en el panel" → `actor.attemptsTo(NavigateTo.thePageAt(Constants.BASE_URL))`; step "crea un nuevo folio" → `actor.attemptsTo(CreateFolio.fromDashboard())`; step "completa los datos" → `actor.attemptsTo(CompleteGeneralInfo.withDefaultTestData())`; step "ambas secciones muestran estado completo" → `assertThat(actor.asksAbout(SectionCompletionStatus.forBothSections())).contains("Asegurado", "Suscripción")`; step "folio avanza al paso de layout" → `assertThat(actor.asksAbout(WizardStepIndicator.currentStep())).containsIgnoringCase("Layout")`
+- [x] T015 [US1] Crear `src/test/java/com/sofka/automation/stepdefinitions/FolioCreationStepDefinitions.java`: implementar los 4 steps del feature file usando `OnStage.theActorCalled("Agente")`; step "está en el panel" → `actor.attemptsTo(NavigateTo.thePageAt(Constants.BASE_URL))`; step "crea un nuevo folio" → `actor.attemptsTo(CreateFolio.fromDashboard())`; step "completa los datos" → `actor.attemptsTo(CompleteGeneralInfo.withDefaultTestData())`; step "ambas secciones muestran estado completo" → `assertThat(actor.asksAbout(SectionCompletionStatus.forBothSections())).contains("Asegurado", "Suscripción")`; step "folio avanza al paso de layout" → `assertThat(actor.asksAbout(WizardStepIndicator.currentStep())).containsIgnoringCase("Layout")`
 
 **Checkpoint**: `./gradlew clean test aggregate` ejecuta el escenario completo sin errores. Reporte en `target/site/serenity/`.
 
@@ -68,8 +68,8 @@
 
 ## Phase N: Polish & Cross-Cutting Concerns
 
-- [ ] T016 [P] Crear `README.md` en raíz con: requisitos previos, comando de ejecución `./gradlew clean test aggregate`, ubicación del reporte, configuración del browser, estructura del proyecto
-- [ ] T017 Validar ejecución end-to-end siguiendo `specs/001-folio-creation-general-info/quickstart.md`: verificar que todos los SC-001 a SC-005 pasan, reporte Serenity generado con capturas por step
+- [x] T016 [P] Crear `README.md` en raíz con: requisitos previos, comando de ejecución `./gradlew clean test aggregate`, ubicación del reporte, configuración del browser, estructura del proyecto
+- [x] T017 Validar ejecución end-to-end siguiendo `specs/001-folio-creation-general-info/quickstart.md`: verificar que todos los SC-001 a SC-005 pasan, reporte Serenity generado con capturas por step
 
 ---
 

--- a/src/test/java/com/sofka/automation/hooks/CatalogSetupHook.java
+++ b/src/test/java/com/sofka/automation/hooks/CatalogSetupHook.java
@@ -1,0 +1,71 @@
+package com.sofka.automation.hooks;
+
+import com.sofka.automation.utils.Constants;
+import io.cucumber.java.Before;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import io.restassured.response.Response;
+
+import java.util.List;
+
+public class CatalogSetupHook {
+
+    @Before(order = 1)
+    public void ensureCatalogsExist() {
+        ensureSubscriberExists();
+        ensureAgentExists();
+    }
+
+    private void ensureSubscriberExists() {
+        Response getResponse = RestAssured
+                .given().baseUri(Constants.BACKEND_BASE_URL)
+                .get("/v1/subscribers");
+
+        assertSuccessful(getResponse, "GET /v1/subscribers");
+
+        List<?> subscribers = getResponse.jsonPath().getList("$");
+        if (subscribers.isEmpty()) {
+            Response postResponse = RestAssured
+                    .given().baseUri(Constants.BACKEND_BASE_URL)
+                    .contentType(ContentType.JSON)
+                    .body(String.format(
+                            "{\"id\":\"%s\",\"name\":\"%s\"}",
+                            Constants.TEST_SUBSCRIBER_ID,
+                            Constants.TEST_SUBSCRIBER_NAME))
+                    .post("/v1/subscribers");
+
+            assertSuccessful(postResponse, "POST /v1/subscribers");
+        }
+    }
+
+    private void ensureAgentExists() {
+        Response getResponse = RestAssured
+                .given().baseUri(Constants.BACKEND_BASE_URL)
+                .get("/v1/agents");
+
+        assertSuccessful(getResponse, "GET /v1/agents");
+
+        List<?> agents = getResponse.jsonPath().getList("$");
+        if (agents.isEmpty()) {
+            Response postResponse = RestAssured
+                    .given().baseUri(Constants.BACKEND_BASE_URL)
+                    .contentType(ContentType.JSON)
+                    .body(String.format(
+                            "{\"code\":\"%s\",\"name\":\"%s\"}",
+                            Constants.TEST_AGENT_CODE,
+                            Constants.TEST_AGENT_NAME))
+                    .post("/v1/agents");
+
+            assertSuccessful(postResponse, "POST /v1/agents");
+        }
+    }
+
+    private void assertSuccessful(Response response, String operation) {
+        int status = response.getStatusCode();
+        if (status < 200 || status >= 300) {
+            throw new IllegalStateException(
+                    "CatalogSetupHook: " + operation + " retornó " + status +
+                    " — verificar que el backend está corriendo en " + Constants.BACKEND_BASE_URL);
+        }
+    }
+}

--- a/src/test/java/com/sofka/automation/questions/SectionCompletionStatus.java
+++ b/src/test/java/com/sofka/automation/questions/SectionCompletionStatus.java
@@ -1,0 +1,29 @@
+package com.sofka.automation.questions;
+
+import net.serenitybdd.screenplay.Actor;
+import net.serenitybdd.screenplay.Question;
+import net.serenitybdd.screenplay.abilities.BrowseTheWeb;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class SectionCompletionStatus implements Question<List<String>> {
+
+    public static SectionCompletionStatus forBothSections() {
+        return new SectionCompletionStatus();
+    }
+
+    @Override
+    public List<String> answeredBy(Actor actor) {
+        List<WebElement> titles = BrowseTheWeb.as(actor).getDriver()
+                .findElements(By.xpath(
+                        "//div[contains(@class,'card-header')]" +
+                        "[.//span[contains(@class,'badge-ok')]]" +
+                        "//p[@class='card-title']"));
+        return titles.stream()
+                .map(WebElement::getText)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/test/java/com/sofka/automation/questions/WizardStepIndicator.java
+++ b/src/test/java/com/sofka/automation/questions/WizardStepIndicator.java
@@ -1,0 +1,20 @@
+package com.sofka.automation.questions;
+
+import net.serenitybdd.screenplay.Actor;
+import net.serenitybdd.screenplay.Question;
+import net.serenitybdd.screenplay.abilities.BrowseTheWeb;
+import org.openqa.selenium.By;
+
+public class WizardStepIndicator implements Question<String> {
+
+    public static WizardStepIndicator currentStep() {
+        return new WizardStepIndicator();
+    }
+
+    @Override
+    public String answeredBy(Actor actor) {
+        return BrowseTheWeb.as(actor).getDriver()
+                .findElement(By.cssSelector(".step[aria-current='true'] span"))
+                .getText();
+    }
+}

--- a/src/test/java/com/sofka/automation/runners/FolioTestRunner.java
+++ b/src/test/java/com/sofka/automation/runners/FolioTestRunner.java
@@ -1,0 +1,21 @@
+package com.sofka.automation.runners;
+
+import org.junit.platform.suite.api.ConfigurationParameter;
+import org.junit.platform.suite.api.ConfigurationParameters;
+import org.junit.platform.suite.api.IncludeEngines;
+import org.junit.platform.suite.api.SelectClasspathResource;
+import org.junit.platform.suite.api.Suite;
+
+@Suite
+@IncludeEngines("cucumber")
+@SelectClasspathResource("features/folio_creation_general_info.feature")
+@ConfigurationParameters({
+        @ConfigurationParameter(
+                key = "cucumber.glue",
+                value = "com.sofka.automation.stepdefinitions,com.sofka.automation.hooks"),
+        @ConfigurationParameter(
+                key = "cucumber.plugin",
+                value = "io.cucumber.core.plugin.SerenityReporterParallel")
+})
+public class FolioTestRunner {
+}

--- a/src/test/java/com/sofka/automation/stepdefinitions/FolioCreationStepDefinitions.java
+++ b/src/test/java/com/sofka/automation/stepdefinitions/FolioCreationStepDefinitions.java
@@ -1,0 +1,75 @@
+package com.sofka.automation.stepdefinitions;
+
+import com.sofka.automation.questions.SectionCompletionStatus;
+import com.sofka.automation.questions.WizardStepIndicator;
+import com.sofka.automation.targets.GeneralInfoTargets;
+import com.sofka.automation.tasks.ui.CompleteGeneralInfo;
+import com.sofka.automation.tasks.ui.CreateFolio;
+import com.sofka.automation.utils.Constants;
+import io.cucumber.java.After;
+import io.cucumber.java.Before;
+import io.cucumber.java.en.And;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
+import net.serenitybdd.screenplay.Actor;
+import net.serenitybdd.screenplay.actions.Click;
+import net.serenitybdd.screenplay.actions.Open;
+import net.serenitybdd.screenplay.cast.Cast;
+import net.serenitybdd.screenplay.matchers.WebElementStateMatchers;
+import net.serenitybdd.screenplay.stage.OnStage;
+import net.serenitybdd.screenplay.waits.WaitUntil;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class FolioCreationStepDefinitions {
+
+    @Before(order = 10)
+    public void setTheStage() {
+        OnStage.setTheStage(Cast.whereEveryoneCanBrowseTheWeb());
+    }
+
+    @After
+    public void teardown() {
+        OnStage.drawTheCurtain();
+    }
+
+    @Given("que el agente está en el panel de cotizaciones")
+    public void elAgenteEstaEnElPanel() {
+        OnStage.theActorCalled("Agente").attemptsTo(
+                Open.url(Constants.BASE_URL)
+        );
+    }
+
+    @When("crea un nuevo folio seleccionando suscriptor y agente")
+    public void creaUnNuevoFolio() {
+        OnStage.theActorInTheSpotlight().attemptsTo(
+                CreateFolio.fromDashboard()
+        );
+    }
+
+    @And("completa los datos del asegurado y suscripción")
+    public void completaLosDatos() {
+        OnStage.theActorInTheSpotlight().attemptsTo(
+                CompleteGeneralInfo.withDefaultTestData()
+        );
+    }
+
+    @Then("ambas secciones muestran estado completo y el folio avanza al paso de layout")
+    public void verificarEstadoCompleto() {
+        Actor actor = OnStage.theActorInTheSpotlight();
+
+        assertThat(actor.asksAbout(SectionCompletionStatus.forBothSections()))
+                .as("Las secciones Asegurado y Suscripción deben mostrar badge Completo")
+                .contains("Asegurado", "Suscripción");
+
+        actor.attemptsTo(
+                Click.on(GeneralInfoTargets.NEXT_BUTTON),
+                WaitUntil.the(GeneralInfoTargets.WIZARD_ACTIVE_STEP, WebElementStateMatchers.isVisible())
+        );
+
+        assertThat(actor.asksAbout(WizardStepIndicator.currentStep()))
+                .as("El wizard debe estar en el paso Layout")
+                .containsIgnoringCase("Layout");
+    }
+}

--- a/src/test/java/com/sofka/automation/targets/DashboardTargets.java
+++ b/src/test/java/com/sofka/automation/targets/DashboardTargets.java
@@ -1,0 +1,27 @@
+package com.sofka.automation.targets;
+
+import net.serenitybdd.screenplay.targets.Target;
+import org.openqa.selenium.By;
+
+public class DashboardTargets {
+
+    public static final Target NEW_FOLIO_BUTTON = Target
+            .the("botón Nuevo folio")
+            .located(By.xpath("//button[contains(normalize-space(.), 'Nuevo folio')]"));
+
+    public static final Target MODAL = Target
+            .the("modal de creación de folio")
+            .located(By.cssSelector(".modal[role='dialog']"));
+
+    public static final Target SUBSCRIBER_DROPDOWN = Target
+            .the("dropdown Suscriptor en modal")
+            .located(By.cssSelector("#subscriberId select.select"));
+
+    public static final Target AGENT_DROPDOWN = Target
+            .the("dropdown Agente en modal")
+            .located(By.cssSelector("#agentCode select.select"));
+
+    public static final Target CREATE_FOLIO_BUTTON = Target
+            .the("botón Crear folio en modal")
+            .located(By.xpath("//div[contains(@class,'modal__footer')]//button[contains(normalize-space(.),'Crear folio')]"));
+}

--- a/src/test/java/com/sofka/automation/targets/GeneralInfoTargets.java
+++ b/src/test/java/com/sofka/automation/targets/GeneralInfoTargets.java
@@ -1,0 +1,47 @@
+package com.sofka.automation.targets;
+
+import net.serenitybdd.screenplay.targets.Target;
+import org.openqa.selenium.By;
+
+public class GeneralInfoTargets {
+
+    public static final Target PAGE_FORM = Target
+            .the("formulario de datos generales")
+            .located(By.cssSelector("form.page-form"));
+
+    public static final Target RAZON_SOCIAL_INPUT = Target
+            .the("campo Razón social")
+            .located(By.xpath("//div[contains(@class,'field')][.//label[contains(.,'Razón social')]]//input[@class='input']"));
+
+    public static final Target RFC_INPUT = Target
+            .the("campo RFC")
+            .located(By.xpath("//div[contains(@class,'field')][.//label[contains(.,'RFC')]]//input[@class='input']"));
+
+    public static final Target EMAIL_INPUT = Target
+            .the("campo Correo de contacto")
+            .located(By.xpath("//div[contains(@class,'field')][.//label[contains(.,'Correo de contacto')]]//input[@class='input']"));
+
+    public static final Target PHONE_INPUT = Target
+            .the("campo Teléfono")
+            .located(By.xpath("//div[contains(@class,'field')][.//label[contains(.,'Teléfono')]]//input[@class='input']"));
+
+    public static final Target RISK_CLASSIFICATION_DROPDOWN = Target
+            .the("dropdown Clasificación de riesgo")
+            .located(By.xpath("//div[contains(@class,'field')][.//label[contains(.,'Clasificación de riesgo')]]//select[@class='select']"));
+
+    public static final Target BUSINESS_TYPE_DROPDOWN = Target
+            .the("dropdown Tipo de negocio")
+            .located(By.xpath("//div[contains(@class,'field')][.//label[contains(.,'Tipo de negocio')]]//select[@class='select']"));
+
+    public static final Target NEXT_BUTTON = Target
+            .the("botón Siguiente")
+            .located(By.cssSelector("button[type='submit'].btn--primary"));
+
+    public static final Target SECTION_COMPLETE_BADGE = Target
+            .the("badge sección completa")
+            .located(By.cssSelector(".card-header span.badge-ok"));
+
+    public static final Target WIZARD_ACTIVE_STEP = Target
+            .the("paso activo del wizard")
+            .located(By.cssSelector(".step[aria-current='true'] span"));
+}

--- a/src/test/java/com/sofka/automation/tasks/ui/CompleteGeneralInfo.java
+++ b/src/test/java/com/sofka/automation/tasks/ui/CompleteGeneralInfo.java
@@ -1,0 +1,28 @@
+package com.sofka.automation.tasks.ui;
+
+import com.sofka.automation.targets.GeneralInfoTargets;
+import com.sofka.automation.utils.Constants;
+import net.serenitybdd.screenplay.Actor;
+import net.serenitybdd.screenplay.Task;
+import net.serenitybdd.screenplay.Tasks;
+import net.serenitybdd.screenplay.actions.Enter;
+import net.serenitybdd.screenplay.actions.SelectFromOptions;
+
+public class CompleteGeneralInfo implements Task {
+
+    public static CompleteGeneralInfo withDefaultTestData() {
+        return Tasks.instrumented(CompleteGeneralInfo.class);
+    }
+
+    @Override
+    public <T extends Actor> void performAs(T actor) {
+        actor.attemptsTo(
+                Enter.theValue(Constants.TEST_RAZON_SOCIAL).into(GeneralInfoTargets.RAZON_SOCIAL_INPUT),
+                Enter.theValue(Constants.TEST_RFC).into(GeneralInfoTargets.RFC_INPUT),
+                Enter.theValue(Constants.TEST_EMAIL).into(GeneralInfoTargets.EMAIL_INPUT),
+                Enter.theValue(Constants.TEST_PHONE).into(GeneralInfoTargets.PHONE_INPUT),
+                SelectFromOptions.byIndex(1).from(GeneralInfoTargets.RISK_CLASSIFICATION_DROPDOWN),
+                SelectFromOptions.byIndex(1).from(GeneralInfoTargets.BUSINESS_TYPE_DROPDOWN)
+        );
+    }
+}

--- a/src/test/java/com/sofka/automation/tasks/ui/CreateFolio.java
+++ b/src/test/java/com/sofka/automation/tasks/ui/CreateFolio.java
@@ -1,0 +1,44 @@
+package com.sofka.automation.tasks.ui;
+
+import com.sofka.automation.targets.DashboardTargets;
+import com.sofka.automation.targets.GeneralInfoTargets;
+import com.sofka.automation.utils.Constants;
+import net.serenitybdd.screenplay.Actor;
+import net.serenitybdd.screenplay.Task;
+import net.serenitybdd.screenplay.Tasks;
+import net.serenitybdd.screenplay.abilities.BrowseTheWeb;
+import net.serenitybdd.screenplay.actions.Click;
+import net.serenitybdd.screenplay.actions.Open;
+import net.serenitybdd.screenplay.actions.SelectFromOptions;
+import net.serenitybdd.screenplay.matchers.WebElementStateMatchers;
+import net.serenitybdd.screenplay.waits.WaitUntil;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class CreateFolio implements Task {
+
+    public static CreateFolio fromDashboard() {
+        return Tasks.instrumented(CreateFolio.class);
+    }
+
+    @Override
+    public <T extends Actor> void performAs(T actor) {
+        actor.attemptsTo(
+                Open.url(Constants.BASE_URL),
+                Click.on(DashboardTargets.NEW_FOLIO_BUTTON),
+                WaitUntil.the(DashboardTargets.SUBSCRIBER_DROPDOWN, WebElementStateMatchers.isVisible()),
+                SelectFromOptions.byIndex(1).from(DashboardTargets.SUBSCRIBER_DROPDOWN),
+                SelectFromOptions.byIndex(1).from(DashboardTargets.AGENT_DROPDOWN),
+                Click.on(DashboardTargets.CREATE_FOLIO_BUTTON),
+                WaitUntil.the(GeneralInfoTargets.PAGE_FORM, WebElementStateMatchers.isVisible())
+        );
+
+        String currentUrl = BrowseTheWeb.as(actor).getDriver().getCurrentUrl();
+        Pattern pattern = Pattern.compile("(FOL-\\d{4}-\\d+)");
+        Matcher matcher = pattern.matcher(currentUrl);
+        if (matcher.find()) {
+            actor.remember("folioNumber", matcher.group(1));
+        }
+    }
+}

--- a/src/test/java/com/sofka/automation/utils/Constants.java
+++ b/src/test/java/com/sofka/automation/utils/Constants.java
@@ -1,0 +1,20 @@
+package com.sofka.automation.utils;
+
+public final class Constants {
+
+    public static final String BASE_URL          = "http://localhost:4200";
+    public static final String BACKEND_BASE_URL  = "http://localhost:8080";
+    public static final String CORE_BASE_URL     = "http://localhost:8081";
+
+    public static final String TEST_RAZON_SOCIAL     = "Empresa Prueba SA de CV";
+    public static final String TEST_RFC              = "EPR860101AB2";
+    public static final String TEST_EMAIL            = "prueba@automation.com";
+    public static final String TEST_PHONE            = "5512345678";
+
+    public static final String TEST_SUBSCRIBER_ID   = "SUB-TEST";
+    public static final String TEST_SUBSCRIBER_NAME = "Suscriptor Automatización";
+    public static final String TEST_AGENT_CODE      = "AGT-TEST";
+    public static final String TEST_AGENT_NAME      = "Agente Automatización";
+
+    private Constants() {}
+}

--- a/src/test/resources/features/folio_creation_general_info.feature
+++ b/src/test/resources/features/folio_creation_general_info.feature
@@ -1,0 +1,13 @@
+# language: es
+
+Característica: Creación de folio y captura de datos generales
+  Como agente del cotizador
+  Quiero crear un folio nuevo y completar los datos generales
+  Para avanzar al paso de layout con ambas secciones completas
+
+  @folio-creation
+  Escenario: Completar datos generales y avanzar al layout
+    Dado que el agente está en el panel de cotizaciones
+    Cuando crea un nuevo folio seleccionando suscriptor y agente
+    Y completa los datos del asegurado y suscripción
+    Entonces ambas secciones muestran estado completo y el folio avanza al paso de layout

--- a/src/test/resources/serenity.conf
+++ b/src/test/resources/serenity.conf
@@ -1,0 +1,16 @@
+webdriver {
+  driver = chrome
+  timeouts {
+    implicitlywait = 5000
+    pageLoadTimeout = 30000
+  }
+}
+
+serenity {
+  project.name = "Insurance Quoter Auto Front"
+  reports = ["single-page-html"]
+}
+
+restapi {
+  base.url = "http://localhost:8080"
+}


### PR DESCRIPTION
## Release v1.0.0

Primer release del proyecto de automatización UI. Incluye el flujo completo de creación de folio y captura de datos generales (HU-FRONT-01).

## Cambios

- Setup completo del proyecto: Gradle, Serenity BDD 4.2.34, Screenplay, Selenium 4.33.0
- Especificaciones en `specs/001-folio-creation-general-info/` (spec, plan, research, data-model, contracts, quickstart, tasks)
- 17 GitHub issues implementados y cerrados
- Flujo automatizado end-to-end:
  - `CatalogSetupHook` — precondiciones vía API
  - `CreateFolio` — creación de folio desde dashboard
  - `CompleteGeneralInfo` — captura de datos asegurado y suscripción
  - `SectionCompletionStatus` — verificación de badges "● Completo"
  - `WizardStepIndicator` — verificación de avance al paso Layout

## Ejecutar

```bash
./gradlew clean test aggregate
```

## PR de origen

Mergeado desde #18 (feat: `001-folio-creation-general-info` → develop)